### PR TITLE
Add events to InfluxDB Sites dashboard

### DIFF
--- a/v2.0.0/UniFi-Poller_ Network Sites - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ Network Sites - InfluxDB.json
@@ -73,7 +73,7 @@
         "iconColor": "#B877D9",
         "limit": 100,
         "name": "AP Events",
-        "query": "select \"key\" as \"title\", \"msg\",\"ssid\",\"hostname\",\"host\",\"radio\"  from \"unifi_events\" WHERE subsystem='wlan' AND $timeFilter ORDER BY time DESC LIMIT 100",
+        "query": "select \"key\" as \"title\", \"msg\",\"ssid\",\"hostname\",\"host\",\"radio\"  from \"unifi_events\" WHERE subsystem='wlan' AND source =~ /^$Controller$/ AND \"site_name\" =~ /^$site$/ AND $timeFilter ORDER BY time DESC LIMIT 100",
         "showIn": 0,
         "tags": [],
         "tagsColumn": "ssid,hostname,host,radio,title",
@@ -84,13 +84,27 @@
         "datasource": "${DS_UNIFI_POLLER}",
         "enable": false,
         "hide": false,
-        "iconColor": "rgba(255, 96, 96, 1)",
+        "iconColor": "#96D98D",
         "limit": 100,
         "name": "Other Events",
-        "query": "select \"key\" as \"title\", \"msg\",\"subsystem\",\"ssid\",\"network\",\"hostname\",\"host\" from \"unifi_events\" WHERE subsystem!='wlan' AND $timeFilter ORDER BY time DESC LIMIT 100",
+        "query": "select \"key\" as \"title\", \"msg\",\"subsystem\",\"ssid\",\"network\",\"hostname\",\"host\" from \"unifi_events\" WHERE subsystem!='wlan' AND source =~ /^$Controller$/ AND \"site_name\" =~ /^$site$/AND $timeFilter ORDER BY time DESC LIMIT 100",
         "showIn": 0,
         "tags": [],
         "tagsColumn": "subsystem,ssid,network,hostname,host",
+        "textColumn": "msg",
+        "type": "tags"
+      },
+      {
+        "datasource": "${DS_UNIFI_POLLER}",
+        "enable": false,
+        "hide": false,
+        "iconColor": "#C4162A",
+        "limit": 100,
+        "name": "IDS Events",
+        "query": "select \"key\", \"msg\",\"subsystem\",\"catname\",\"app_proto\",\"inner_alert_action\",\"dstip_country_name\" from \"unifi_ids\"  WHERE $timeFilter AND source =~ /^$Controller$/ AND \"site_name\" =~ /^$site$/ ORDER BY time DESC LIMIT 100",
+        "showIn": 0,
+        "tags": [],
+        "tagsColumn": "key,subsystem,catname,app_proto,inner_alert_action,dstip_country_name",
         "textColumn": "msg",
         "type": "tags"
       }
@@ -101,7 +115,7 @@
   "gnetId": 10414,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1592863440119,
+  "iteration": 1593063896147,
   "links": [
     {
       "asDropdown": true,
@@ -138,8 +152,9 @@
   ],
   "panels": [
     {
-      "content": "Each site contains 5 subsystems: wan, lan, wlan, www, vpn. \nEach subsystem contains data specific to that system, \nbut every subsystem shares the same fields. \nThis means that most fields you find appear empty. \nThat means the field is probably for a different subsystem.\nThe site metrics contain a lot of data about the local USG.\nNote: The three singlestat panels with thresholds do not have\na subsystem selected and they may not be entirely accurate.\n\nThe Events and AP Events selectors only work if save_events is \nturned on (and you have events to display). They display events\nfor all sites on all sites, sorry, but annotations can only be\nmade per-Dashboard. Use these as examples for your own dashboards.\n",
+      "content": "Each site contains 5 subsystems: wan, lan, wlan, www, vpn. \nEach subsystem contains data specific to that system, \nbut every subsystem shares the same fields. \nThis means that most fields you find appear empty. \nThat means the field is probably for a different subsystem.\nThe site metrics contain a lot of data about the local USG.\nNote: The three singlestat panels with thresholds do not have\na subsystem selected and they may not be entirely accurate.\n<br><br>\nThe three Events selectors only work if save_events and\nsave_ids (for IDS) is turned on (and you have events to\ndisplay). They display events for all sites on all sites,\nsorry, but annotations can only be made per-Dashboard. Use\nthese as examples for your own dashboards.\n",
       "datasource": "${DS_UNIFI_POLLER}",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -173,7 +188,7 @@
       "panels": [
         {
           "datasource": "${DS_UNIFI_POLLER}",
-          "description": "This only contains data if save_events is turned on in the UniFi Poller configuration.",
+          "description": "This only contains data if save_events and/or save_ids are set true in the poller configuration.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -181,7 +196,7 @@
               },
               "mappings": [],
               "thresholds": {
-                "mode": "absolute",
+                "mode": "percentage",
                 "steps": [
                   {
                     "color": "green",
@@ -203,31 +218,7 @@
                 "properties": [
                   {
                     "id": "custom.width",
-                    "value": 157
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "subsystem"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 86
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "key"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 173
+                    "value": 170
                   }
                 ]
               },
@@ -239,24 +230,58 @@
                 "properties": [
                   {
                     "id": "custom.width",
-                    "value": 235
-                  },
+                    "value": 189
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "subsystem"
+                },
+                "properties": [
                   {
-                    "id": "noValue",
-                    "value": "-"
+                    "id": "custom.width",
+                    "value": 87
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "key"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 186
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "host"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 136
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 10,
+            "h": 12,
             "w": 24,
             "x": 0,
             "y": 6
           },
           "id": 40,
+          "interval": "",
           "options": {
+            "frameIndex": 0,
             "showHeader": true,
             "sortBy": []
           },
@@ -270,15 +295,25 @@
           },
           "targets": [
             {
+              "alias": "as",
               "groupBy": [],
+              "hide": false,
               "measurement": "unifi_events",
-              "orderByTime": "DESC",
+              "orderByTime": "ASC",
               "policy": "default",
-              "query": "SELECT \"site_name\", \"hostname\", \"hostname\" FROM \"unifi_events\" WHERE (\"site_name\" =~ /^$site$/) AND $timeFilter",
+              "query": "SELECT \"hostname\", \"subsystem\", \"key\", \"msg\" FROM \"unifi_events\" WHERE (\"site_name\" =~ /^$site$/) AND $timeFilter",
               "rawQuery": false,
               "refId": "A",
               "resultFormat": "table",
               "select": [
+                [
+                  {
+                    "params": [
+                      "hostname"
+                    ],
+                    "type": "field"
+                  }
+                ],
                 [
                   {
                     "params": [
@@ -290,7 +325,52 @@
                 [
                   {
                     "params": [
-                      "hostname"
+                      "key"
+                    ],
+                    "type": "field"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "msg"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "site_name",
+                  "operator": "=~",
+                  "value": "/^$site$/"
+                }
+              ]
+            },
+            {
+              "alias": "as",
+              "groupBy": [],
+              "hide": false,
+              "measurement": "unifi_ids",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT \"subsystem\", \"hostname\", \"key\", \"msg\" FROM \"unifi_events\" WHERE (\"site_name\" =~ /^$site$/) AND $timeFilter ORDER BY time DESC",
+              "rawQuery": false,
+              "refId": "B",
+              "resultFormat": "table",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "host"
+                    ],
+                    "type": "field"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "subsystem"
                     ],
                     "type": "field"
                   }
@@ -323,7 +403,8 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": " $site Events",
+          "title": "$site Events & IDS",
+          "transformations": [],
           "type": "table"
         },
         {
@@ -354,7 +435,7 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 16
+            "y": 18
           },
           "id": 32,
           "interval": null,
@@ -474,7 +555,7 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 16
+            "y": 18
           },
           "id": 33,
           "interval": null,
@@ -594,7 +675,7 @@
             "h": 4,
             "w": 3,
             "x": 6,
-            "y": 16
+            "y": 18
           },
           "id": 34,
           "interval": null,
@@ -714,7 +795,7 @@
             "h": 4,
             "w": 3,
             "x": 9,
-            "y": 16
+            "y": 18
           },
           "id": 35,
           "interval": null,
@@ -820,7 +901,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 18
           },
           "id": 14,
           "links": [],
@@ -1017,7 +1098,7 @@
             "h": 2,
             "w": 2,
             "x": 0,
-            "y": 20
+            "y": 22
           },
           "id": 18,
           "interval": null,
@@ -1137,7 +1218,7 @@
             "h": 2,
             "w": 2,
             "x": 2,
-            "y": 20
+            "y": 22
           },
           "id": 19,
           "interval": null,
@@ -1257,7 +1338,7 @@
             "h": 2,
             "w": 2,
             "x": 4,
-            "y": 20
+            "y": 22
           },
           "id": 17,
           "interval": null,
@@ -1377,7 +1458,7 @@
             "h": 2,
             "w": 2,
             "x": 6,
-            "y": 20
+            "y": 22
           },
           "id": 24,
           "interval": null,
@@ -1497,7 +1578,7 @@
             "h": 2,
             "w": 2,
             "x": 8,
-            "y": 20
+            "y": 22
           },
           "id": 28,
           "interval": null,
@@ -1617,7 +1698,7 @@
             "h": 2,
             "w": 2,
             "x": 10,
-            "y": 20
+            "y": 22
           },
           "id": 29,
           "interval": null,
@@ -1737,7 +1818,7 @@
             "h": 2,
             "w": 2,
             "x": 12,
-            "y": 20
+            "y": 22
           },
           "id": 26,
           "interval": null,
@@ -1843,7 +1924,7 @@
             "h": 4,
             "w": 5,
             "x": 14,
-            "y": 20
+            "y": 22
           },
           "id": 10,
           "links": [],
@@ -1994,7 +2075,7 @@
             "h": 4,
             "w": 5,
             "x": 19,
-            "y": 20
+            "y": 22
           },
           "id": 11,
           "links": [],
@@ -2198,7 +2279,7 @@
             "h": 2,
             "w": 2,
             "x": 0,
-            "y": 22
+            "y": 24
           },
           "id": 30,
           "interval": null,
@@ -2319,7 +2400,7 @@
             "h": 2,
             "w": 2,
             "x": 2,
-            "y": 22
+            "y": 24
           },
           "id": 27,
           "interval": null,
@@ -2433,7 +2514,7 @@
             "h": 2,
             "w": 2,
             "x": 4,
-            "y": 22
+            "y": 24
           },
           "id": 22,
           "interval": null,
@@ -2547,7 +2628,7 @@
             "h": 2,
             "w": 2,
             "x": 6,
-            "y": 22
+            "y": 24
           },
           "id": 25,
           "interval": null,
@@ -2661,7 +2742,7 @@
             "h": 2,
             "w": 2,
             "x": 8,
-            "y": 22
+            "y": 24
           },
           "id": 20,
           "interval": null,
@@ -2775,7 +2856,7 @@
             "h": 2,
             "w": 2,
             "x": 10,
-            "y": 22
+            "y": 24
           },
           "id": 31,
           "interval": null,
@@ -2895,7 +2976,7 @@
             "h": 2,
             "w": 2,
             "x": 12,
-            "y": 22
+            "y": 24
           },
           "id": 21,
           "interval": null,
@@ -3001,7 +3082,7 @@
             "h": 3,
             "w": 24,
             "x": 0,
-            "y": 24
+            "y": 26
           },
           "id": 12,
           "links": [],
@@ -3203,7 +3284,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 27
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 15,
@@ -3388,7 +3469,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 35
+            "y": 37
           },
           "hiddenSeries": false,
           "id": 2,
@@ -3584,7 +3665,7 @@
             "h": 15,
             "w": 24,
             "x": 0,
-            "y": 42
+            "y": 44
           },
           "hiddenSeries": false,
           "id": 38,
@@ -3795,10 +3876,10 @@
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
         "definition": "show tag values from \"subsystems\" with key=\"site_name\" WHERE source =~ /^$Controller$/ ",
-        "hide": 2,
+        "hide": 0,
         "includeAll": true,
-        "label": "",
-        "multi": false,
+        "label": "Sites",
+        "multi": true,
         "name": "site",
         "options": [],
         "query": "show tag values from \"subsystems\" with key=\"site_name\" WHERE source =~ /^$Controller$/ ",
@@ -3866,5 +3947,5 @@
   "timezone": "browser",
   "title": "UniFi-Poller: Network Sites - InfluxDB",
   "uid": "5_omrT7Zz",
-  "version": 34
+  "version": 47
 }

--- a/v2.0.0/UniFi-Poller_ Network Sites - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ Network Sites - InfluxDB.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "6.6.0"
+      "version": "7.0.3"
     },
     {
       "type": "panel",
@@ -42,6 +42,12 @@
     },
     {
       "type": "panel",
+      "id": "table-old",
+      "name": "Table (old)",
+      "version": ""
+    },
+    {
+      "type": "panel",
       "id": "text",
       "name": "Text",
       "version": ""
@@ -55,17 +61,47 @@
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
         "name": "Annotations & Alerts",
+        "showIn": 0,
         "type": "dashboard"
+      },
+      {
+        "datasource": "${DS_UNIFI_POLLER}",
+        "enable": false,
+        "hide": false,
+        "iconColor": "#B877D9",
+        "limit": 100,
+        "name": "AP Events",
+        "query": "select \"key\" as \"title\", \"msg\",\"ssid\",\"hostname\",\"host\",\"radio\"  from \"unifi_events\" WHERE subsystem='wlan' AND $timeFilter ORDER BY time DESC LIMIT 100",
+        "showIn": 0,
+        "tags": [],
+        "tagsColumn": "ssid,hostname,host,radio,title",
+        "textColumn": "msg",
+        "type": "tags"
+      },
+      {
+        "datasource": "${DS_UNIFI_POLLER}",
+        "enable": false,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Other Events",
+        "query": "select \"key\" as \"title\", \"msg\",\"subsystem\",\"ssid\",\"network\",\"hostname\",\"host\" from \"unifi_events\" WHERE subsystem!='wlan' AND $timeFilter ORDER BY time DESC LIMIT 100",
+        "showIn": 0,
+        "tags": [],
+        "tagsColumn": "subsystem,ssid,network,hostname,host",
+        "textColumn": "msg",
+        "type": "tags"
       }
     ]
   },
-  "description": "UniFi Poller v2.0 Displays detailed information for network Sites in a UniFi controller.",
+  "description": "UniFi Poller v2.0.2 Displays detailed information for network Sites in a UniFi controller.",
   "editable": true,
   "gnetId": 10414,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1580615239248,
+  "iteration": 1592863440119,
   "links": [
     {
       "asDropdown": true,
@@ -102,10 +138,16 @@
   ],
   "panels": [
     {
-      "content": "Each site contains 5 subsystems: wan, lan, wlan, www, vpn. Each subsystem contains data specific to that system, but every subsystem shares the same fields. \nThis means that most fields you find appear empty. That means the field is probably for a different subsystem.\nThe site metrics tend to contain a lot of data about the local USG.\nNote: The three singlestat panels with thresholds do not have a subsystem selected and they may not be entirely accurate.\n\n",
+      "content": "Each site contains 5 subsystems: wan, lan, wlan, www, vpn. \nEach subsystem contains data specific to that system, \nbut every subsystem shares the same fields. \nThis means that most fields you find appear empty. \nThat means the field is probably for a different subsystem.\nThe site metrics contain a lot of data about the local USG.\nNote: The three singlestat panels with thresholds do not have\na subsystem selected and they may not be entirely accurate.\n\nThe Events and AP Events selectors only work if save_events is \nturned on (and you have events to display). They display events\nfor all sites on all sites, sorry, but annotations can only be\nmade per-Dashboard. Use these as examples for your own dashboards.\n",
       "datasource": "${DS_UNIFI_POLLER}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "gridPos": {
-        "h": 3,
+        "h": 5,
         "w": 24,
         "x": 0,
         "y": 0
@@ -113,7 +155,6 @@
       "id": 37,
       "links": [],
       "mode": "html",
-      "options": {},
       "timeFrom": null,
       "timeShift": null,
       "title": "Information",
@@ -126,10 +167,165 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 5
       },
       "id": 4,
       "panels": [
+        {
+          "datasource": "${DS_UNIFI_POLLER}",
+          "description": "This only contains data if save_events is turned on in the UniFi Poller configuration.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": null
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 157
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "subsystem"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 86
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "key"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 173
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "hostname"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 235
+                  },
+                  {
+                    "id": "noValue",
+                    "value": "-"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          },
+          "id": 40,
+          "options": {
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "7.0.3",
+          "scopedVars": {
+            "site": {
+              "selected": false,
+              "text": "Home (default)",
+              "value": "Home (default)"
+            }
+          },
+          "targets": [
+            {
+              "groupBy": [],
+              "measurement": "unifi_events",
+              "orderByTime": "DESC",
+              "policy": "default",
+              "query": "SELECT \"site_name\", \"hostname\", \"hostname\" FROM \"unifi_events\" WHERE (\"site_name\" =~ /^$site$/) AND $timeFilter",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "table",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "subsystem"
+                    ],
+                    "type": "field"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "hostname"
+                    ],
+                    "type": "field"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "key"
+                    ],
+                    "type": "field"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "msg"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "site_name",
+                  "operator": "=~",
+                  "value": "/^$site$/"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": " $site Events",
+          "type": "table"
+        },
         {
           "cacheTimeout": null,
           "colorBackground": false,
@@ -140,6 +336,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "ms",
           "gauge": {
             "maxValue": 400,
@@ -152,7 +354,7 @@
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 4
+            "y": 16
           },
           "id": 32,
           "interval": null,
@@ -171,7 +373,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -255,6 +456,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "ms",
           "gauge": {
             "maxValue": 200,
@@ -267,7 +474,7 @@
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 4
+            "y": 16
           },
           "id": 33,
           "interval": null,
@@ -286,7 +493,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -370,6 +576,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "percent",
           "gauge": {
             "maxValue": 100,
@@ -382,7 +594,7 @@
             "h": 4,
             "w": 3,
             "x": 6,
-            "y": 4
+            "y": 16
           },
           "id": 34,
           "interval": null,
@@ -401,7 +613,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -485,6 +696,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "percent",
           "gauge": {
             "maxValue": 100,
@@ -497,7 +714,7 @@
             "h": 4,
             "w": 3,
             "x": 9,
-            "y": 4
+            "y": 16
           },
           "id": 35,
           "interval": null,
@@ -516,7 +733,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -593,16 +809,21 @@
         {
           "columns": [],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fontSize": "100%",
           "gridPos": {
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 4
+            "y": 16
           },
           "id": 14,
           "links": [],
-          "options": {},
           "pageSize": null,
           "scopedVars": {
             "site": {
@@ -766,7 +987,7 @@
           "timeShift": null,
           "title": "WWW Subsystem",
           "transform": "table",
-          "type": "table"
+          "type": "table-old"
         },
         {
           "cacheTimeout": null,
@@ -778,6 +999,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -790,7 +1017,7 @@
             "h": 2,
             "w": 2,
             "x": 0,
-            "y": 8
+            "y": 20
           },
           "id": 18,
           "interval": null,
@@ -809,7 +1036,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -893,6 +1119,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -905,7 +1137,7 @@
             "h": 2,
             "w": 2,
             "x": 2,
-            "y": 8
+            "y": 20
           },
           "id": 19,
           "interval": null,
@@ -924,7 +1156,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -1008,6 +1239,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1020,7 +1257,7 @@
             "h": 2,
             "w": 2,
             "x": 4,
-            "y": 8
+            "y": 20
           },
           "id": 17,
           "interval": null,
@@ -1039,7 +1276,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -1123,6 +1359,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1135,7 +1377,7 @@
             "h": 2,
             "w": 2,
             "x": 6,
-            "y": 8
+            "y": 20
           },
           "id": 24,
           "interval": null,
@@ -1154,7 +1396,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -1238,6 +1479,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1250,7 +1497,7 @@
             "h": 2,
             "w": 2,
             "x": 8,
-            "y": 8
+            "y": 20
           },
           "id": 28,
           "interval": null,
@@ -1269,7 +1516,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -1353,6 +1599,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1365,7 +1617,7 @@
             "h": 2,
             "w": 2,
             "x": 10,
-            "y": 8
+            "y": 20
           },
           "id": 29,
           "interval": null,
@@ -1384,7 +1636,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -1468,6 +1719,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1480,7 +1737,7 @@
             "h": 2,
             "w": 2,
             "x": 12,
-            "y": 8
+            "y": 20
           },
           "id": 26,
           "interval": null,
@@ -1499,7 +1756,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -1576,16 +1832,21 @@
         {
           "columns": [],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fontSize": "100%",
           "gridPos": {
             "h": 4,
             "w": 5,
             "x": 14,
-            "y": 8
+            "y": 20
           },
           "id": 10,
           "links": [],
-          "options": {},
           "pageSize": null,
           "scopedVars": {
             "site": {
@@ -1717,21 +1978,26 @@
           "timeShift": null,
           "title": "VPN Subsystem",
           "transform": "table",
-          "type": "table"
+          "type": "table-old"
         },
         {
           "columns": [],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fontSize": "100%",
           "gridPos": {
             "h": 4,
             "w": 5,
             "x": 19,
-            "y": 8
+            "y": 20
           },
           "id": 11,
           "links": [],
-          "options": {},
           "pageSize": null,
           "scopedVars": {
             "site": {
@@ -1902,7 +2168,7 @@
           "timeShift": null,
           "title": "LAN Subsystem",
           "transform": "table",
-          "type": "table"
+          "type": "table-old"
         },
         {
           "cacheTimeout": null,
@@ -1914,6 +2180,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1926,7 +2198,7 @@
             "h": 2,
             "w": 2,
             "x": 0,
-            "y": 10
+            "y": 22
           },
           "id": 30,
           "interval": null,
@@ -1945,7 +2217,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -2030,6 +2301,12 @@
           ],
           "datasource": "${DS_UNIFI_POLLER}",
           "description": "This panel currently does not select a subsystem, so the data reflected here may only be fore 1 random system. Keep this in mind when you build your own graphs from this data.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -2042,7 +2319,7 @@
             "h": 2,
             "w": 2,
             "x": 2,
-            "y": 10
+            "y": 22
           },
           "id": 27,
           "interval": null,
@@ -2061,7 +2338,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -2139,6 +2415,12 @@
             "#C4162A"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -2151,7 +2433,7 @@
             "h": 2,
             "w": 2,
             "x": 4,
-            "y": 10
+            "y": 22
           },
           "id": 22,
           "interval": null,
@@ -2170,7 +2452,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -2248,6 +2529,12 @@
             "#C4162A"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -2260,7 +2547,7 @@
             "h": 2,
             "w": 2,
             "x": 6,
-            "y": 10
+            "y": 22
           },
           "id": 25,
           "interval": null,
@@ -2279,7 +2566,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -2357,6 +2643,12 @@
             "#C4162A"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -2369,7 +2661,7 @@
             "h": 2,
             "w": 2,
             "x": 8,
-            "y": 10
+            "y": 22
           },
           "id": 20,
           "interval": null,
@@ -2388,7 +2680,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -2466,6 +2757,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -2478,7 +2775,7 @@
             "h": 2,
             "w": 2,
             "x": 10,
-            "y": 10
+            "y": 22
           },
           "id": 31,
           "interval": null,
@@ -2497,7 +2794,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -2581,6 +2877,12 @@
             "#d44a3a"
           ],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -2593,7 +2895,7 @@
             "h": 2,
             "w": 2,
             "x": 12,
-            "y": 10
+            "y": 22
           },
           "id": 21,
           "interval": null,
@@ -2612,7 +2914,6 @@
           "maxDataPoints": 100,
           "nullPointMode": "connected",
           "nullText": null,
-          "options": {},
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -2689,16 +2990,21 @@
         {
           "columns": [],
           "datasource": "${DS_UNIFI_POLLER}",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fontSize": "100%",
           "gridPos": {
             "h": 3,
             "w": 24,
             "x": 0,
-            "y": 12
+            "y": 24
           },
           "id": 12,
           "links": [],
-          "options": {},
           "pageSize": null,
           "scopedVars": {
             "site": {
@@ -2875,7 +3181,7 @@
           "timeShift": null,
           "title": "WAN Subsystem",
           "transform": "table",
-          "type": "table"
+          "type": "table-old"
         },
         {
           "aliasColors": {},
@@ -2885,13 +3191,19 @@
           "datasource": "${DS_UNIFI_POLLER}",
           "decimals": null,
           "description": "Shows data transfer for each subsystem on the site. RX is on the negative axis.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 15
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 15,
@@ -3064,13 +3376,19 @@
           "datasource": "${DS_UNIFI_POLLER}",
           "decimals": 0,
           "description": "This graphs shows clients connected to the site.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 23
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 2,
@@ -3254,13 +3572,19 @@
           "datasource": "${DS_UNIFI_POLLER}",
           "decimals": 0,
           "description": "This graph only works if DPI is enabled on the controller and DPI collection is enabled in UniFi Poller. Rx is on the negative axis.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 15,
             "w": 24,
             "x": 0,
-            "y": 30
+            "y": 42
           },
           "hiddenSeries": false,
           "id": 38,
@@ -3436,7 +3760,7 @@
       "type": "row"
     }
   ],
-  "schemaVersion": 22,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [
     "unifi",
@@ -3542,5 +3866,5 @@
   "timezone": "browser",
   "title": "UniFi-Poller: Network Sites - InfluxDB",
   "uid": "5_omrT7Zz",
-  "version": 9
+  "version": 34
 }

--- a/v2.0.0/UniFi-Poller_ USW Insights - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ USW Insights - InfluxDB.json
@@ -863,7 +863,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Switch Tmperature",
+      "title": "Switch Temperature",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
This updates the InfluxDB Sites dashboard to add Events and IDS. Mostly for demonstration purposes.

Re: https://github.com/unifi-poller/unifi-poller/issues/220