### PR TITLE
Piechart plugin fix and Prometheus name fix

### DIFF
--- a/v2.0.0/UniFi-Poller_ Client DPI - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ Client DPI - InfluxDB.json
@@ -18,7 +18,7 @@
     },
     {
       "type": "panel",
-      "id": "grafana-piechart-panel",
+      "id": "piechart",
       "name": "Pie Chart",
       "version": "1.3.9"
     },
@@ -660,7 +660,7 @@
       "timeFrom": null,
       "title": "Total Traffic by Application",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -844,7 +844,7 @@
       "timeFrom": null,
       "title": "Total Traffic by Category",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {

--- a/v2.0.0/UniFi-Poller_ Client DPI - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ Client DPI - Prometheus.json
@@ -18,7 +18,7 @@
     },
     {
       "type": "panel",
-      "id": "grafana-piechart-panel",
+      "id": "piechart",
       "name": "Pie Chart",
       "version": "1.5.0"
     },
@@ -405,7 +405,7 @@
       "timeFrom": null,
       "title": "Total Traffic by Category",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -463,7 +463,7 @@
       "timeFrom": null,
       "title": "Total Traffic by Application",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {

--- a/v2.0.0/UniFi-Poller_ Client DPI - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ Client DPI - Prometheus.json
@@ -293,7 +293,7 @@
       ],
       "targets": [
         {
-          "expr": "sum by (site_name, category) (unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"})",
+          "expr": "sum by (site_name, category) (unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -301,7 +301,7 @@
           "refId": "F"
         },
         {
-          "expr": "sum by (site_name, category) (unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"})",
+          "expr": "sum by (site_name, category) (unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -309,7 +309,7 @@
           "refId": "E"
         },
         {
-          "expr": "sum by (site_name, category) (increase(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"}[$__range]))",
+          "expr": "sum by (site_name, category) (increase(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"}[$__range]))",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -317,7 +317,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum by (site_name, category) (increase(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"}[$__range]))",
+          "expr": "sum by (site_name, category) (increase(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"}[$__range]))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -326,7 +326,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (site_name, category)  (increase(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"}[$__range]))",
+          "expr": "sum by (site_name, category)  (increase(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"}[$__range]))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -335,7 +335,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum by (site_name, category)  (increase(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"}[$__range]))",
+          "expr": "sum by (site_name, category)  (increase(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", category=~\"$Category\"}[$__range]))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -395,7 +395,7 @@
       "strokeWidth": "1",
       "targets": [
         {
-          "expr": "sum by (category) (increase(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__range])+increase(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__range]))",
+          "expr": "sum by (category) (increase(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__range])+increase(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__range]))",
           "instant": true,
           "interval": "",
           "legendFormat": "{{category}}",
@@ -453,7 +453,7 @@
       "strokeWidth": "1",
       "targets": [
         {
-          "expr": " sum by (category, application) (increase(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__range])+increase(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\",  category=~\"$Category\"}[$__range]))",
+          "expr": " sum by (category, application) (increase(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__range])+increase(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\",  category=~\"$Category\"}[$__range]))",
           "instant": true,
           "interval": "",
           "legendFormat": "{{application}} ({{category}})",
@@ -526,13 +526,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (category)(rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__interval]))",
+          "expr": "sum by (category)(rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__interval]))",
           "interval": "$Smooth",
           "legendFormat": " {{category}} Rx",
           "refId": "A"
         },
         {
-          "expr": "sum by (category)(rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\",  category=~\"$Category\"}[$__interval]))",
+          "expr": "sum by (category)(rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\",  category=~\"$Category\"}[$__interval]))",
           "interval": "$Smooth",
           "legendFormat": "{{category}} Tx",
           "refId": "B"
@@ -641,13 +641,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (category)(rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__interval]))",
+          "expr": "sum by (category)(rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__interval]))",
           "interval": "$Smooth",
           "legendFormat": " {{category}} Rx",
           "refId": "A"
         },
         {
-          "expr": "sum by (category)(rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__interval]))",
+          "expr": "sum by (category)(rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__interval]))",
           "interval": "$Smooth",
           "legendFormat": "{{category}} Tx",
           "refId": "B"
@@ -768,7 +768,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -880,7 +880,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -992,7 +992,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1104,7 +1104,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1216,7 +1216,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1328,7 +1328,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1440,7 +1440,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1552,7 +1552,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1664,7 +1664,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1776,7 +1776,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1888,7 +1888,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2000,7 +2000,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2112,7 +2112,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2224,7 +2224,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2336,7 +2336,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2448,7 +2448,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2560,7 +2560,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2672,7 +2672,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2784,7 +2784,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2896,7 +2896,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3008,7 +3008,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3120,7 +3120,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3232,7 +3232,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3344,7 +3344,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3456,7 +3456,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3568,7 +3568,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3680,7 +3680,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3792,7 +3792,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3904,7 +3904,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4016,7 +4016,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4128,7 +4128,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4240,7 +4240,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4352,7 +4352,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4464,7 +4464,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4576,7 +4576,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4688,7 +4688,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4800,7 +4800,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4912,7 +4912,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5024,7 +5024,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5136,7 +5136,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5248,7 +5248,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5360,7 +5360,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5472,7 +5472,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5584,7 +5584,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5696,7 +5696,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5808,7 +5808,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5920,7 +5920,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6032,7 +6032,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6144,7 +6144,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6256,7 +6256,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6368,7 +6368,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6480,7 +6480,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6592,7 +6592,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6704,7 +6704,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6816,7 +6816,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6928,7 +6928,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7040,7 +7040,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7152,7 +7152,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7264,7 +7264,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7376,7 +7376,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7488,7 +7488,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7600,7 +7600,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7712,7 +7712,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7824,7 +7824,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7936,7 +7936,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8048,7 +8048,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8160,7 +8160,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8272,7 +8272,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8384,7 +8384,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8496,7 +8496,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8608,7 +8608,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8733,7 +8733,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8845,7 +8845,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8957,7 +8957,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9069,7 +9069,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9181,7 +9181,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9293,7 +9293,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9405,7 +9405,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9517,7 +9517,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9629,7 +9629,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9741,7 +9741,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9853,7 +9853,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9965,7 +9965,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10077,7 +10077,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10189,7 +10189,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10301,7 +10301,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10413,7 +10413,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10525,7 +10525,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10637,7 +10637,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10749,7 +10749,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10861,7 +10861,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10973,7 +10973,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11085,7 +11085,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11197,7 +11197,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11309,7 +11309,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11421,7 +11421,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11533,7 +11533,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11645,7 +11645,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11757,7 +11757,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11869,7 +11869,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11981,7 +11981,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12093,7 +12093,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12205,7 +12205,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12317,7 +12317,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12429,7 +12429,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12541,7 +12541,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12653,7 +12653,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12765,7 +12765,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12877,7 +12877,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12989,7 +12989,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13101,7 +13101,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13213,7 +13213,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13325,7 +13325,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13437,7 +13437,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13549,7 +13549,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13661,7 +13661,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13773,7 +13773,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13885,7 +13885,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13997,7 +13997,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14109,7 +14109,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14221,7 +14221,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14333,7 +14333,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14445,7 +14445,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14557,7 +14557,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14669,7 +14669,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14781,7 +14781,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14893,7 +14893,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15005,7 +15005,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15117,7 +15117,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15229,7 +15229,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15341,7 +15341,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15453,7 +15453,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15565,7 +15565,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15677,7 +15677,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15802,7 +15802,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15914,7 +15914,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16026,7 +16026,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16138,7 +16138,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16250,7 +16250,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16362,7 +16362,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16474,7 +16474,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16586,7 +16586,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16698,7 +16698,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16810,7 +16810,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16922,7 +16922,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17034,7 +17034,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17146,7 +17146,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17258,7 +17258,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17370,7 +17370,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17482,7 +17482,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17594,7 +17594,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17706,7 +17706,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17818,7 +17818,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17930,7 +17930,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18042,7 +18042,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18154,7 +18154,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18266,7 +18266,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18378,7 +18378,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18490,7 +18490,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18602,7 +18602,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18714,7 +18714,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18826,7 +18826,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18938,7 +18938,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19050,7 +19050,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19162,7 +19162,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19274,7 +19274,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19386,7 +19386,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19498,7 +19498,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19610,7 +19610,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19722,7 +19722,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19834,7 +19834,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19946,7 +19946,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20058,7 +20058,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20170,7 +20170,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20282,7 +20282,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20394,7 +20394,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20506,7 +20506,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20618,7 +20618,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20730,7 +20730,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20842,7 +20842,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20954,7 +20954,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21066,7 +21066,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21178,7 +21178,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21290,7 +21290,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21402,7 +21402,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21514,7 +21514,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21626,7 +21626,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21738,7 +21738,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21850,7 +21850,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21962,7 +21962,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22074,7 +22074,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22186,7 +22186,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22298,7 +22298,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22410,7 +22410,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22522,7 +22522,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22634,7 +22634,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22746,7 +22746,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22871,7 +22871,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -22984,7 +22984,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23097,7 +23097,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23210,7 +23210,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23323,7 +23323,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23436,7 +23436,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23549,7 +23549,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23662,7 +23662,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23775,7 +23775,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23888,7 +23888,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24001,7 +24001,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24114,7 +24114,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24227,7 +24227,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24340,7 +24340,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24453,7 +24453,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24566,7 +24566,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24679,7 +24679,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24792,7 +24792,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24905,7 +24905,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25018,7 +25018,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25131,7 +25131,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25244,7 +25244,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25357,7 +25357,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25470,7 +25470,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25583,7 +25583,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25696,7 +25696,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25809,7 +25809,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25922,7 +25922,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26035,7 +26035,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26148,7 +26148,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26261,7 +26261,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26374,7 +26374,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26487,7 +26487,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26600,7 +26600,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26713,7 +26713,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26826,7 +26826,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26939,7 +26939,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27052,7 +27052,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27165,7 +27165,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27278,7 +27278,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27391,7 +27391,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27504,7 +27504,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27617,7 +27617,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27730,7 +27730,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27843,7 +27843,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27956,7 +27956,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28069,7 +28069,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28182,7 +28182,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28295,7 +28295,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28408,7 +28408,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28521,7 +28521,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28634,7 +28634,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28747,7 +28747,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28860,7 +28860,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28973,7 +28973,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29086,7 +29086,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29199,7 +29199,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29312,7 +29312,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29425,7 +29425,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29538,7 +29538,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29651,7 +29651,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29764,7 +29764,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29877,7 +29877,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -30002,7 +30002,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by ($Identifier,application) (rate(unifipoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
+              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{mac}} ({{application}})",
               "refId": "A"
@@ -30109,7 +30109,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by ($Identifier,application) (rate(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
+              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{mac}} ({{application}})",
               "refId": "A"
@@ -30217,7 +30217,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by ($Identifier,application) (rate(unifipoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
+              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{mac}} ({{application}})",
               "refId": "A"
@@ -30324,7 +30324,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by ($Identifier,application) (rate(unifipoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
+              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{mac}} ({{application}})",
               "refId": "A"
@@ -30412,14 +30412,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_client_uptime_seconds{source=~\"$Controller\"},site_name)",
+        "definition": "label_values(unpoller_client_uptime_seconds{source=~\"$Controller\"},site_name)",
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": true,
         "name": "Site",
         "options": [],
-        "query": "label_values(unifipoller_client_uptime_seconds{source=~\"$Controller\"},site_name)",
+        "query": "label_values(unpoller_client_uptime_seconds{source=~\"$Controller\"},site_name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -30463,14 +30463,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\"},[[Identifier]])",
+        "definition": "label_values(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\"},[[Identifier]])",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Client",
         "options": [],
-        "query": "label_values(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\"},[[Identifier]])",
+        "query": "label_values(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\"},[[Identifier]])",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -30485,14 +30485,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\"},category)",
+        "definition": "label_values(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\"},category)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Category",
         "options": [],
-        "query": "label_values(unifipoller_client_dpi_transmit_bytes{site_name=~\"$Site\"},category)",
+        "query": "label_values(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\"},category)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/v2.0.0/UniFi-Poller_ Client Insights - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ Client Insights - InfluxDB.json
@@ -18,7 +18,7 @@
     },
     {
       "type": "panel",
-      "id": "grafana-piechart-panel",
+      "id": "piechart",
       "name": "Pie Chart",
       "version": "1.5.0"
     },
@@ -929,7 +929,7 @@
       "timeShift": null,
       "title": "Clients / Channel",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -1016,7 +1016,7 @@
       "timeFrom": "5m",
       "title": "Clients / AP Radio",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -1104,7 +1104,7 @@
       "timeFrom": "5m",
       "title": "Client MAC OUI Breakdown",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -1190,7 +1190,7 @@
       "timeFrom": "5m",
       "title": "OS/Dev Class/ID Breakdown",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {

--- a/v2.0.0/UniFi-Poller_ Client Insights - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ Client Insights - Prometheus.json
@@ -601,7 +601,7 @@
       ],
       "targets": [
         {
-          "expr": "sum by (channel,essid,ip,mac,name,network,oui,radio_desc,site_name,source) (\n unifipoller_client_receive_bytes_total{wired!=\"true\", site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by (channel,essid,ip,mac,name,network,oui,radio_desc,site_name,source) (\n unpoller_client_receive_bytes_total{wired!=\"true\", site_name=~\"$Site\", name=~\"$Wireless\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -609,7 +609,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum by (channel,essid,ip,mac,name,network,oui,radio_desc,site_name,source) (\n unifipoller_client_transmit_bytes_total{wired!=\"true\",site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by (channel,essid,ip,mac,name,network,oui,radio_desc,site_name,source) (\n unpoller_client_transmit_bytes_total{wired!=\"true\",site_name=~\"$Site\", name=~\"$Wireless\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -617,7 +617,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (channel,essid,ip,mac,name,network,oui,radio_desc,site_name,source) (\n unifipoller_client_uptime_seconds{wired!=\"true\",site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by (channel,essid,ip,mac,name,network,oui,radio_desc,site_name,source) (\n unpoller_client_uptime_seconds{wired!=\"true\",site_name=~\"$Site\", name=~\"$Wireless\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -1009,14 +1009,14 @@
       ],
       "targets": [
         {
-          "expr": "sum by (ap_name,ip,mac,name,network,oui,site_name,source,sw_port) (\n     unifipoller_client_uptime_seconds{wired=\"true\", site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
+          "expr": "sum by (ap_name,ip,mac,name,network,oui,site_name,source,sw_port) (\n     unpoller_client_uptime_seconds{wired=\"true\", site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
           "format": "table",
           "instant": true,
           "interval": "",
           "refId": "A"
         },
         {
-          "expr": "sum by (ap_name,ip,mac,name,network,oui,site_name,source,sw_port) (\n     unifipoller_client_receive_bytes_total{wired=\"true\", site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
+          "expr": "sum by (ap_name,ip,mac,name,network,oui,site_name,source,sw_port) (\n     unpoller_client_receive_bytes_total{wired=\"true\", site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1024,7 +1024,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (ap_name,ip,mac,name,network,oui,site_name,source,sw_port) (\n     unifipoller_client_transmit_bytes_total{wired=\"true\", site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
+          "expr": "sum by (ap_name,ip,mac,name,network,oui,site_name,source,sw_port) (\n     unpoller_client_transmit_bytes_total{wired=\"true\", site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1079,13 +1079,13 @@
       "strokeWidth": "2",
       "targets": [
         {
-          "expr": "count by (hostname) (unifipoller_client_uptime_seconds{site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
+          "expr": "count by (hostname) (unpoller_client_uptime_seconds{site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
           "instant": true,
           "legendFormat": "Wired",
           "refId": "A"
         },
         {
-          "expr": "count by (channel) (unifipoller_client_roam_count_total{site_name=~\"$Site\", name=~\"$Wireless\", ap_name=~\"$AP\"})",
+          "expr": "count by (channel) (unpoller_client_roam_count_total{site_name=~\"$Site\", name=~\"$Wireless\", ap_name=~\"$AP\"})",
           "instant": true,
           "interval": "$Smooth",
           "legendFormat": "Channel {{channel}}",
@@ -1140,7 +1140,7 @@
       "strokeWidth": "3",
       "targets": [
         {
-          "expr": "count by (radio_proto) (unifipoller_client_roam_count_total{site_name=~\"$Site\", name=~\"$Wireless\", ap_name=~\"$AP\"})",
+          "expr": "count by (radio_proto) (unpoller_client_roam_count_total{site_name=~\"$Site\", name=~\"$Wireless\", ap_name=~\"$AP\"})",
           "instant": true,
           "interval": "$Smooth",
           "legendFormat": "{{radio_proto}}",
@@ -1198,7 +1198,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "count by (oui) (unifipoller_client_uptime_seconds{site_name=~\"$Site\", name=~\"$Wireless\", ap_name=~\"$AP\"})",
+          "expr": "count by (oui) (unpoller_client_uptime_seconds{site_name=~\"$Site\", name=~\"$Wireless\", ap_name=~\"$AP\"})",
           "hide": false,
           "instant": true,
           "interval": "$Smooth",
@@ -1206,7 +1206,7 @@
           "refId": "A"
         },
         {
-          "expr": "count by (oui) (+unifipoller_client_uptime_seconds{site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
+          "expr": "count by (oui) (+unpoller_client_uptime_seconds{site_name=~\"$Site\", name=~\"$Wired\", sw_name=~\"$Switch\"})",
           "hide": false,
           "instant": true,
           "interval": "$Smooth",
@@ -1281,14 +1281,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_transmit_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
           "instant": false,
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}} Tx",
           "refId": "B"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_receive_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
           "instant": false,
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}} Rx",
@@ -1396,13 +1396,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_transmit_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}} Tx",
           "refId": "A"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_receive_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
           "hide": false,
           "interval": "$Smooth",
           "intervalFactor": 1,
@@ -1511,28 +1511,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_transmit_bytes_total{name=~\"^amazon.*\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name=~\"^amazon.*\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "w {{name}} {{mac}} Tx",
           "refId": "A"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_receive_bytes_total{name=~\"^amazon.*\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name=~\"^amazon.*\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "w {{name}} {{mac}} Rx",
           "refId": "B"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_transmit_bytes_total{name=~\"^amazon.*\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name=~\"^amazon.*\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "e {{name}} {{mac}} Tx",
           "refId": "C"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_receive_bytes_total{name=~\"^amazon.*\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name=~\"^amazon.*\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "e {{name}} {{mac}} Rx",
@@ -1640,7 +1640,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_transmit_bytes_total{ap_name=~\"$AP\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{ap_name=~\"$AP\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
           "hide": false,
           "instant": false,
           "interval": "$Smooth",
@@ -1648,21 +1648,21 @@
           "refId": "A"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_receive_bytes_total{ap_name=~\"$AP\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{ap_name=~\"$AP\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "w {{name}} {{mac}} Rx",
           "refId": "B"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_transmit_bytes_total{sw_name=~\"$Switch\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{sw_name=~\"$Switch\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "e {{name}} {{mac}} Tx",
           "refId": "C"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_receive_bytes_total{sw_name=~\"$Switch\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{sw_name=~\"$Switch\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "e {{name}} {{mac}} Rx",
@@ -1765,7 +1765,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (unifipoller_client_rssi_db{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by ($Identifier) (unpoller_client_rssi_db{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
           "interval": "1m",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -1869,7 +1869,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (unifipoller_client_radio_signal_db{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by ($Identifier) (unpoller_client_radio_signal_db{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
           "instant": false,
           "interval": "$Smooth",
           "intervalFactor": 1,
@@ -1975,7 +1975,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (unifipoller_client_noise_db{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by ($Identifier) (unpoller_client_noise_db{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
           "instant": false,
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
@@ -2077,7 +2077,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (unifipoller_client_radio_transmit_rate_bps{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by ($Identifier) (unpoller_client_radio_transmit_rate_bps{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -2180,7 +2180,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by ($Identifier) (rate(unifipoller_client_wifi_attempts_transmit_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"}[$__interval]))",
+          "expr": "avg by ($Identifier) (rate(unpoller_client_wifi_attempts_transmit_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"}[$__interval]))",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -2284,7 +2284,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (unifipoller_client_radio_receive_rate_bps{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by ($Identifier) (unpoller_client_radio_receive_rate_bps{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -2388,7 +2388,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (rate(unifipoller_client_transmit_retries_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_retries_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"}[$__interval]))",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -2491,7 +2491,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (unifipoller_client_radio_transmit_power_dbm{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by ($Identifier) (unpoller_client_radio_transmit_power_dbm{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -2594,7 +2594,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (unifipoller_client_anomalies{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by ($Identifier) (unpoller_client_anomalies{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -2698,7 +2698,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (unifipoller_client_satisfaction_ratio{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by ($Identifier) (unpoller_client_satisfaction_ratio{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -2802,7 +2802,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (unifipoller_client_roam_count_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by ($Identifier) (unpoller_client_roam_count_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -2905,7 +2905,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (unifipoller_client_ccq_ratio{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
+          "expr": "sum by ($Identifier) (unpoller_client_ccq_ratio{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"})",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -2967,14 +2967,14 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_client_uptime_seconds,source)",
+        "definition": "label_values(unpoller_client_uptime_seconds,source)",
         "hide": 2,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Controller",
         "options": [],
-        "query": "label_values(unifipoller_client_uptime_seconds,source)",
+        "query": "label_values(unpoller_client_uptime_seconds,source)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -2989,14 +2989,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_client_uptime_seconds{source=~\"$Controller\"},site_name)",
+        "definition": "label_values(unpoller_client_uptime_seconds{source=~\"$Controller\"},site_name)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Site",
         "options": [],
-        "query": "label_values(unifipoller_client_uptime_seconds{source=~\"$Controller\"},site_name)",
+        "query": "label_values(unpoller_client_uptime_seconds{source=~\"$Controller\"},site_name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -3011,14 +3011,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_client_uptime_seconds{site_name=~\"$Site\"},ap_name)",
+        "definition": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\"},ap_name)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "AP",
         "options": [],
-        "query": "label_values(unifipoller_client_uptime_seconds{site_name=~\"$Site\"},ap_name)",
+        "query": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\"},ap_name)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -3033,14 +3033,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_client_uptime_seconds{site_name=~\"$Site\"},sw_name)",
+        "definition": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\"},sw_name)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Switch",
         "options": [],
-        "query": "label_values(unifipoller_client_uptime_seconds{site_name=~\"$Site\"},sw_name)",
+        "query": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\"},sw_name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -3055,14 +3055,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_client_uptime_seconds{site_name=~\"$Site\", ap_name=~\"$AP\", wired=\"false\"},name)",
+        "definition": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\", ap_name=~\"$AP\", wired=\"false\"},name)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Wireless",
         "options": [],
-        "query": "label_values(unifipoller_client_uptime_seconds{site_name=~\"$Site\", ap_name=~\"$AP\", wired=\"false\"},name)",
+        "query": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\", ap_name=~\"$AP\", wired=\"false\"},name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -3077,14 +3077,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_client_uptime_seconds{site_name=~\"$Site\", sw_name=~\"$Switch\", wired=\"true\"},name)",
+        "definition": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\", sw_name=~\"$Switch\", wired=\"true\"},name)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Wired",
         "options": [],
-        "query": "label_values(unifipoller_client_uptime_seconds{site_name=~\"$Site\", sw_name=~\"$Switch\", wired=\"true\"},name)",
+        "query": "label_values(unpoller_client_uptime_seconds{site_name=~\"$Site\", sw_name=~\"$Switch\", wired=\"true\"},name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/v2.0.0/UniFi-Poller_ Client Insights - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ Client Insights - Prometheus.json
@@ -18,7 +18,7 @@
     },
     {
       "type": "panel",
-      "id": "grafana-piechart-panel",
+      "id": "piechart",
       "name": "Pie Chart",
       "version": "1.5.0"
     },
@@ -1095,7 +1095,7 @@
       "timeFrom": null,
       "title": "Clients / Channel",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -1150,7 +1150,7 @@
       "timeFrom": null,
       "title": "Clients / AP Radio",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -1217,7 +1217,7 @@
       "timeFrom": null,
       "title": "Client MAC OUI Breakdown",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {

--- a/v2.0.0/UniFi-Poller_ Network Sites - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ Network Sites - Prometheus.json
@@ -167,7 +167,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(unifipoller_site_switches)",
+          "expr": "sum(unpoller_site_switches)",
           "format": "time_series",
           "instant": true,
           "interval": "$Smooth",
@@ -255,7 +255,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(unifipoller_site_aps)",
+          "expr": "sum(unpoller_site_aps)",
           "format": "time_series",
           "instant": true,
           "interval": "$Smooth",
@@ -343,7 +343,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(unifipoller_site_gateways)",
+          "expr": "sum(unpoller_site_gateways)",
           "format": "time_series",
           "instant": true,
           "interval": "$Smooth",
@@ -431,7 +431,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(unifipoller_site_stations)",
+          "expr": "sum(unpoller_site_stations)",
           "format": "time_series",
           "instant": false,
           "interval": "$Smooth",
@@ -553,7 +553,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "unifipoller_site_uptime_seconds",
+              "expr": "unpoller_site_uptime_seconds",
               "format": "time_series",
               "instant": true,
               "interval": "$Smooth",
@@ -633,49 +633,49 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "unifipoller_site_iots{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_iots{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} IoT",
               "refId": "A"
             },
             {
-              "expr": "unifipoller_site_adopted{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_adopted{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Adopted",
               "refId": "B"
             },
             {
-              "expr": "unifipoller_site_disabled{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_disabled{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Disabled",
               "refId": "C"
             },
             {
-              "expr": "unifipoller_site_disconnected{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_disconnected{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Disconnected",
               "refId": "D"
             },
             {
-              "expr": "unifipoller_site_pending{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_pending{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Pending",
               "refId": "E"
             },
             {
-              "expr": "unifipoller_site_gateways{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_gateways{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Gateways",
               "refId": "F"
             },
             {
-              "expr": "unifipoller_site_switches{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_switches{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Switches",
               "refId": "G"
             },
             {
-              "expr": "unifipoller_site_intenet_drops_total{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_intenet_drops_total{site_name=~\"$Site\",subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Drops",
               "refId": "H"
@@ -793,7 +793,7 @@
           },
           "targets": [
             {
-              "expr": "unifipoller_site_latency_seconds{site_name=~\"$Site\"}",
+              "expr": "unpoller_site_latency_seconds{site_name=~\"$Site\"}",
               "instant": true,
               "interval": "$Smooth",
               "refId": "A"
@@ -873,7 +873,7 @@
           },
           "targets": [
             {
-              "expr": "unifipoller_site_speedtest_ping{site_name=~\"$Site\"}",
+              "expr": "unpoller_site_speedtest_ping{site_name=~\"$Site\"}",
               "interval": "$Smooth",
               "refId": "A"
             }
@@ -945,13 +945,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "unifipoller_site_transmit_rate_bytes{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_transmit_rate_bytes{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Tx",
               "refId": "A"
             },
             {
-              "expr": "unifipoller_site_receive_rate_bytes{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_receive_rate_bytes{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Rx",
               "refId": "B"
@@ -1056,31 +1056,31 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "unifipoller_site_users{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_users{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Users",
               "refId": "A"
             },
             {
-              "expr": "unifipoller_site_guests{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_guests{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Guests",
               "refId": "B"
             },
             {
-              "expr": "unifipoller_site_remote_user_active{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_remote_user_active{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Active",
               "refId": "C"
             },
             {
-              "expr": "unifipoller_site_remote_user_inactive{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_remote_user_inactive{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Inactive",
               "refId": "D"
             },
             {
-              "expr": "unifipoller_site_stations{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
+              "expr": "unpoller_site_stations{site_name=~\"$Site\", subsystem=~\"$Subsystem\"}",
               "interval": "$Smooth",
               "legendFormat": "{{subsystem}} Stations",
               "refId": "E"
@@ -1189,13 +1189,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_site_remote_user_transmit_bytes_total{site_name=~\"$Site\"}[$__interval])",
+              "expr": "rate(unpoller_site_remote_user_transmit_bytes_total{site_name=~\"$Site\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "VPN Users Tx",
               "refId": "A"
             },
             {
-              "expr": "rate(unifipoller_site_remote_user_receive_bytes_total{site_name=~\"$Site\"}[$__interval])",
+              "expr": "rate(unpoller_site_remote_user_receive_bytes_total{site_name=~\"$Site\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "VPN Users Rx",
               "refId": "B"
@@ -1306,14 +1306,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (category) (rate(unifipoller_site_dpi_receive_bytes{site_name=~\"$Site\"}[$__interval]))",
+              "expr": "sum by (category) (rate(unpoller_site_dpi_receive_bytes{site_name=~\"$Site\"}[$__interval]))",
               "hide": false,
               "interval": "$Smooth",
               "legendFormat": "{{category}} Rx",
               "refId": "A"
             },
             {
-              "expr": "sum by (category) (rate(unifipoller_site_dpi_transmit_bytes{site_name=~\"$Site\"}[$__interval]))",
+              "expr": "sum by (category) (rate(unpoller_site_dpi_transmit_bytes{site_name=~\"$Site\"}[$__interval]))",
               "hide": false,
               "interval": "$Smooth",
               "legendFormat": "{{category}} Tx",
@@ -1381,14 +1381,14 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_site_transmit_rate_bytes,source)",
+        "definition": "label_values(unpoller_site_transmit_rate_bytes,source)",
         "hide": 0,
         "includeAll": true,
         "label": "",
         "multi": true,
         "name": "Controller",
         "options": [],
-        "query": "label_values(unifipoller_site_transmit_rate_bytes,source)",
+        "query": "label_values(unpoller_site_transmit_rate_bytes,source)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1403,14 +1403,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_site_transmit_rate_bytes{source=~\"$Controller\"},site_name)",
+        "definition": "label_values(unpoller_site_transmit_rate_bytes{source=~\"$Controller\"},site_name)",
         "hide": 2,
         "includeAll": true,
         "label": "",
         "multi": false,
         "name": "Site",
         "options": [],
-        "query": "label_values(unifipoller_site_transmit_rate_bytes{source=~\"$Controller\"},site_name)",
+        "query": "label_values(unpoller_site_transmit_rate_bytes{source=~\"$Controller\"},site_name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/v2.0.0/UniFi-Poller_ UAP Insights - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ UAP Insights - InfluxDB.json
@@ -24,7 +24,7 @@
     },
     {
       "type": "panel",
-      "id": "grafana-piechart-panel",
+      "id": "piechart",
       "name": "Pie Chart",
       "version": "1.3.9"
     },
@@ -210,7 +210,7 @@
       "timeFrom": "5m",
       "title": "Clients / Channel",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -295,7 +295,7 @@
       "timeFrom": "5m",
       "title": "Clients / AP Band",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -378,7 +378,7 @@
       "timeFrom": "5m",
       "title": "Client / MAC OUI",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {

--- a/v2.0.0/UniFi-Poller_ UAP Insights - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ UAP Insights - Prometheus.json
@@ -184,7 +184,7 @@
       "strokeWidth": "3",
       "targets": [
         {
-          "expr": "count by (channel) (unifipoller_client_roam_count_total{site_name=~\"$Site\", ap_name=~\"$AP\"})\n",
+          "expr": "count by (channel) (unpoller_client_roam_count_total{site_name=~\"$Site\", ap_name=~\"$AP\"})\n",
           "instant": false,
           "interval": "$Smooth",
           "legendFormat": "Ch {{channel}}",
@@ -246,7 +246,7 @@
       "strokeWidth": "3",
       "targets": [
         {
-          "expr": "count by (radio_desc) (unifipoller_client_uptime_seconds{site_name=~\"$Site\", ap_name=~\"$AP\"})",
+          "expr": "count by (radio_desc) (unpoller_client_uptime_seconds{site_name=~\"$Site\", ap_name=~\"$AP\"})",
           "instant": false,
           "interval": "$Smooth",
           "legendFormat": "{{radio_desc}}",
@@ -303,7 +303,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "count by (oui) (unifipoller_client_uptime_seconds{site_name=~\"$Site\", ap_name=~\"$AP\"})",
+          "expr": "count by (oui) (unpoller_client_uptime_seconds{site_name=~\"$Site\", ap_name=~\"$AP\"})",
           "instant": false,
           "interval": "$Smooth",
           "legendFormat": "e {{oui}}",
@@ -387,7 +387,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(unifipoller_device_stations{site_name=~\"$Site\", name=~\"$AP\", station_type=\"user\"})",
+          "expr": "sum(unpoller_device_stations{site_name=~\"$Site\", name=~\"$AP\", station_type=\"user\"})",
           "instant": true,
           "refId": "A"
         }
@@ -471,7 +471,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(unifipoller_device_stations{site_name=~\"$Site\", name=~\"$AP\", station_type=\"guest\"})",
+          "expr": "sum(unpoller_device_stations{site_name=~\"$Site\", name=~\"$AP\", station_type=\"guest\"})",
           "instant": true,
           "refId": "A"
         }
@@ -823,7 +823,7 @@
       ],
       "targets": [
         {
-          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version) (unifipoller_device_info{site_name=~\"$Site\", name=~\"$AP\"})",
+          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version) (unpoller_device_info{site_name=~\"$Site\", name=~\"$AP\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -831,7 +831,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version) (unifipoller_device_uptime_seconds{site_name=~\"$Site\", name=~\"$AP\"})",
+          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version) (unpoller_device_uptime_seconds{site_name=~\"$Site\", name=~\"$AP\"})",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -840,7 +840,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version) (unifipoller_device_bytes_total{site_name=~\"$Site\", name=~\"$AP\"})",
+          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version) (unpoller_device_bytes_total{site_name=~\"$Site\", name=~\"$AP\"})",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1332,14 +1332,14 @@
       ],
       "targets": [
         {
-          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unifipoller_device_vap_ccq_ratio{site_name=~\"$Site\", name=~\"$AP\"})",
+          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_ccq_ratio{site_name=~\"$Site\", name=~\"$AP\"})",
           "format": "table",
           "instant": true,
           "interval": "",
           "refId": "A"
         },
         {
-          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unifipoller_device_vap_average_client_signal{site_name=~\"$Site\", name=~\"$AP\"})",
+          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_average_client_signal{site_name=~\"$Site\", name=~\"$AP\"})",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1347,7 +1347,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unifipoller_device_vap_receive_dropped_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
+          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_receive_dropped_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1355,7 +1355,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unifipoller_device_vap_transmit_dropped_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
+          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_transmit_dropped_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1363,7 +1363,7 @@
           "refId": "E"
         },
         {
-          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unifipoller_device_vap_transmit_bytes_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
+          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_transmit_bytes_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1371,7 +1371,7 @@
           "refId": "F"
         },
         {
-          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unifipoller_device_vap_receive_bytes_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
+          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_receive_bytes_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1379,7 +1379,7 @@
           "refId": "G"
         },
         {
-          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unifipoller_device_vap_receive_packets_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
+          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_receive_packets_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1387,7 +1387,7 @@
           "refId": "H"
         },
         {
-          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unifipoller_device_vap_transmit_packets_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
+          "expr": "sum by (bssid,essid,ap_name,name,radio,radio_name,vap_name,site_name,usage,source) (unpoller_device_vap_transmit_packets_total{site_name=~\"$Site\", name=~\"$AP\"}) ",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1457,7 +1457,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "unifipoller_device_cpu_utilization_ratio{site_name=~\"$Site\",name=~\"$AP\"}",
+          "expr": "unpoller_device_cpu_utilization_ratio{site_name=~\"$Site\",name=~\"$AP\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}}",
           "refId": "A"
@@ -1560,7 +1560,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "unifipoller_device_memory_utilization_ratio{site_name=~\"$Site\",name=~\"$AP\"}",
+          "expr": "unpoller_device_memory_utilization_ratio{site_name=~\"$Site\",name=~\"$AP\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}}",
           "refId": "A"
@@ -1675,20 +1675,20 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "unifipoller_device_load_average_1{site_name=~\"$Site\",name=~\"$AP\"}",
+          "expr": "unpoller_device_load_average_1{site_name=~\"$Site\",name=~\"$AP\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}} load1",
           "refId": "A"
         },
         {
-          "expr": "unifipoller_device_load_average_5{site_name=~\"$Site\",name=~\"$AP\"}",
+          "expr": "unpoller_device_load_average_5{site_name=~\"$Site\",name=~\"$AP\"}",
           "hide": true,
           "interval": "$Smooth",
           "legendFormat": "{{name}} load5",
           "refId": "B"
         },
         {
-          "expr": "unifipoller_device_load_average_15{site_name=~\"$Site\",name=~\"$AP\"}",
+          "expr": "unpoller_device_load_average_15{site_name=~\"$Site\",name=~\"$AP\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}} load15",
           "refId": "C"
@@ -1795,7 +1795,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "unifipoller_device_stations{site_name=~\"$Site\",name=~\"$AP\"}",
+          "expr": "unpoller_device_stations{site_name=~\"$Site\",name=~\"$AP\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}} users",
           "refId": "A"
@@ -1903,13 +1903,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (unifipoller_client_receive_rate_bytes{site_name=~\"$Site\",ap_name=~\"$AP\"}) by (oui)",
+          "expr": "sum (unpoller_client_receive_rate_bytes{site_name=~\"$Site\",ap_name=~\"$AP\"}) by (oui)",
           "interval": "$Smooth",
           "legendFormat": "{{oui}} Rx",
           "refId": "A"
         },
         {
-          "expr": "sum (unifipoller_client_transmit_rate_bytes{site_name=~\"$Site\",ap_name=~\"$AP\"}) by (oui)",
+          "expr": "sum (unpoller_client_transmit_rate_bytes{site_name=~\"$Site\",ap_name=~\"$AP\"}) by (oui)",
           "interval": "$Smooth",
           "legendFormat": "{{oui}} Tx",
           "refId": "B"
@@ -2012,27 +2012,27 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (unifipoller_device_radio_stations{radio=\"ng\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"guest\"}) by  (radio,name)",
+          "expr": "sum (unpoller_device_radio_stations{radio=\"ng\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"guest\"}) by  (radio,name)",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "{{name}} Guests 2,4GHz",
           "refId": "A"
         },
         {
-          "expr": "sum (unifipoller_device_radio_stations{radio=\"ng\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"user\"}) by (radio,name)",
+          "expr": "sum (unpoller_device_radio_stations{radio=\"ng\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"user\"}) by (radio,name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Users  2.4GHz",
           "refId": "B"
         },
         {
-          "expr": "sum (unifipoller_device_radio_stations{radio=\"na\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"user\"}) by (radio,name)",
+          "expr": "sum (unpoller_device_radio_stations{radio=\"na\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"user\"}) by (radio,name)",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "{{name}} Users 5GHz",
           "refId": "C"
         },
         {
-          "expr": "sum (unifipoller_device_radio_stations{radio=\"na\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"guest\"}) by (radio,name)",
+          "expr": "sum (unpoller_device_radio_stations{radio=\"na\", site_name=~\"$Site\",name=~\"$AP\", station_type=\"guest\"}) by (radio,name)",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "{{name}} Guests 5GHz",
@@ -2136,7 +2136,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "unifipoller_device_vap_average_client_signal{name=~\"$AP\"}",
+          "expr": "unpoller_device_vap_average_client_signal{name=~\"$AP\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{vap_name}} {{radio}}",
           "refId": "A"
@@ -2240,7 +2240,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(unifipoller_client_rssi_db{ap_name=~\"$AP\"}) by (ap_name, radio_name)",
+          "expr": "avg(unpoller_client_rssi_db{ap_name=~\"$AP\"}) by (ap_name, radio_name)",
           "interval": "$Smooth",
           "legendFormat": "{{ap_name}}  {{radio_name}}",
           "refId": "A"
@@ -2343,7 +2343,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "unifipoller_device_vap_ccq_ratio{site_name=~\"$Site\",name=~\"$AP\", radio=\"na\"}",
+          "expr": "unpoller_device_vap_ccq_ratio{site_name=~\"$Site\",name=~\"$AP\", radio=\"na\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{vap_name}}",
           "refId": "A"
@@ -2447,7 +2447,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "unifipoller_device_vap_ccq_ratio{site_name=~\"$Site\",name=~\"$AP\", radio=\"ng\"}",
+          "expr": "unpoller_device_vap_ccq_ratio{site_name=~\"$Site\",name=~\"$AP\", radio=\"ng\"}",
           "interval": "1m",
           "legendFormat": "{{name}} {{vap_name}}",
           "refId": "A"
@@ -2557,13 +2557,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "unifipoller_device_radio_channel_utilization_receive_ratio{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}",
+          "expr": "unpoller_device_radio_channel_utilization_receive_ratio{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Rx",
           "refId": "B"
         },
         {
-          "expr": "unifipoller_device_radio_channel_utilization_transmit_ratio{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}",
+          "expr": "unpoller_device_radio_channel_utilization_transmit_ratio{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Tx",
           "refId": "C"
@@ -2672,13 +2672,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "unifipoller_device_radio_channel_utilization_receive_ratio{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}",
+          "expr": "unpoller_device_radio_channel_utilization_receive_ratio{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{radio}} Rx",
           "refId": "B"
         },
         {
-          "expr": "unifipoller_device_radio_channel_utilization_transmit_ratio{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}",
+          "expr": "unpoller_device_radio_channel_utilization_transmit_ratio{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{radio}} Tx",
           "refId": "C"
@@ -2791,13 +2791,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(unifipoller_device_vap_transmit_bytes_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_bytes_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Tx",
           "refId": "A"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_bytes_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_bytes_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}}  Rx",
           "refId": "B"
@@ -2908,13 +2908,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(unifipoller_device_vap_transmit_bytes_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_bytes_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Tx",
           "refId": "A"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_bytes_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_bytes_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[5m])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Rx",
           "refId": "B"
@@ -3024,14 +3024,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(unifipoller_device_vap_transmit_packets_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_packets_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "{{name}} Out",
           "refId": "A"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_packets_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_packets_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} In",
           "refId": "B"
@@ -3143,13 +3143,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(unifipoller_device_vap_transmit_packets_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_packets_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Out",
           "refId": "A"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_packets_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_packets_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} In",
           "refId": "B"
@@ -3261,49 +3261,49 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_dropped_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_dropped_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Drops Rx",
           "refId": "A"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_transmit_dropped_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_dropped_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Drops Tx",
           "refId": "B"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_errors_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_errors_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Errors Rx",
           "refId": "C"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_transmit_errors_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_errors_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Errors Tx",
           "refId": "D"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_crypts_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_crypts_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Crypts Rx",
           "refId": "E"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_frags_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_frags_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Frags Rx",
           "refId": "F"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_nwids_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_nwids_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Nwids Rx",
           "refId": "G"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_transmit_retries_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_retries_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Retries Tx",
           "refId": "H"
@@ -3416,49 +3416,49 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_dropped_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_dropped_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Drops Rx",
           "refId": "A"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_transmit_dropped_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_dropped_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Drops Tx",
           "refId": "B"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_errors_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_errors_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Errors Rx",
           "refId": "C"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_transmit_errors_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_errors_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Errors Tx",
           "refId": "D"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_crypts_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_crypts_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Crypts Rx",
           "refId": "E"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_frags_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_frags_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Frags Rx",
           "refId": "F"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_receive_nwids_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_nwids_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Nwids Rx",
           "refId": "G"
         },
         {
-          "expr": "sum (rate(unifipoller_device_vap_transmit_retries_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_retries_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Retries Tx",
           "refId": "H"
@@ -3523,14 +3523,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_device_info{type=\"uap\"},source)",
+        "definition": "label_values(unpoller_device_info{type=\"uap\"},source)",
         "hide": 2,
         "includeAll": true,
         "label": "",
         "multi": true,
         "name": "Controller",
         "options": [],
-        "query": "label_values(unifipoller_device_info{type=\"uap\"},source)",
+        "query": "label_values(unpoller_device_info{type=\"uap\"},source)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -3545,14 +3545,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_device_info{source=~\"$Controller\", type=\"uap\"},site_name)",
+        "definition": "label_values(unpoller_device_info{source=~\"$Controller\", type=\"uap\"},site_name)",
         "hide": 0,
         "includeAll": true,
         "label": "",
         "multi": true,
         "name": "Site",
         "options": [],
-        "query": "label_values(unifipoller_device_info{source=~\"$Controller\", type=\"uap\"},site_name)",
+        "query": "label_values(unpoller_device_info{source=~\"$Controller\", type=\"uap\"},site_name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -3567,14 +3567,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_device_info{site_name=~\"$Site\", type=~\"uap|udm\",model!=\"UDMPRO\"},name)",
+        "definition": "label_values(unpoller_device_info{site_name=~\"$Site\", type=~\"uap|udm\",model!=\"UDMPRO\"},name)",
         "hide": 0,
         "includeAll": true,
         "label": "UniFi AP:",
         "multi": true,
         "name": "AP",
         "options": [],
-        "query": "label_values(unifipoller_device_info{site_name=~\"$Site\", type=~\"uap|udm\",model!=\"UDMPRO\"},name)",
+        "query": "label_values(unpoller_device_info{site_name=~\"$Site\", type=~\"uap|udm\",model!=\"UDMPRO\"},name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/v2.0.0/UniFi-Poller_ UAP Insights - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ UAP Insights - Prometheus.json
@@ -24,7 +24,7 @@
     },
     {
       "type": "panel",
-      "id": "grafana-piechart-panel",
+      "id": "piechart",
       "name": "Pie Chart",
       "version": "1.5.0"
     },
@@ -194,7 +194,7 @@
       "timeFrom": null,
       "title": "Clients / Channel",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -256,7 +256,7 @@
       "timeFrom": null,
       "title": "Clients / AP Radio",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -313,7 +313,7 @@
       "timeFrom": null,
       "title": "Client / MAC OUI",
       "transparent": true,
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {

--- a/v2.0.0/UniFi-Poller_ USG Insights - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ USG Insights - Prometheus.json
@@ -366,7 +366,7 @@
       ],
       "targets": [
         {
-          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unifipoller_device_info{site_name=~\"$Site\", name=~\"$Gateway\"})",
+          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unpoller_device_info{site_name=~\"$Site\", name=~\"$Gateway\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -374,7 +374,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unifipoller_device_uptime_seconds{site_name=~\"$Site\", name=~\"$Gateway\"})",
+          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unpoller_device_uptime_seconds{site_name=~\"$Site\", name=~\"$Gateway\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -382,7 +382,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unifipoller_device_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"})",
+          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unpoller_device_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -467,7 +467,7 @@
           },
           "targets": [
             {
-              "expr": "unifipoller_device_uptime_seconds{site_name=~\"$Site\", name=~\"$Gateway\"}",
+              "expr": "unpoller_device_uptime_seconds{site_name=~\"$Site\", name=~\"$Gateway\"}",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{name}} Uptime",
@@ -542,14 +542,14 @@
           },
           "targets": [
             {
-              "expr": "unifipoller_device_speedtest_upload{site_name=~\"$Site\", name=~\"$Gateway\"}",
+              "expr": "unpoller_device_speedtest_upload{site_name=~\"$Site\", name=~\"$Gateway\"}",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{name}} Upload",
               "refId": "A"
             },
             {
-              "expr": "unifipoller_device_speedtest_download{site_name=~\"$Site\", name=~\"$Gateway\"}",
+              "expr": "unpoller_device_speedtest_download{site_name=~\"$Site\", name=~\"$Gateway\"}",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{name}} Download",
@@ -624,14 +624,14 @@
           },
           "targets": [
             {
-              "expr": "sum by (name) (unifipoller_device_speedtest_runtime_seconds{site_name=~\"$Site\", name=~\"$Gateway\"})",
+              "expr": "sum by (name) (unpoller_device_speedtest_runtime_seconds{site_name=~\"$Site\", name=~\"$Gateway\"})",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{name}} Test Time",
               "refId": "A"
             },
             {
-              "expr": "sum by (name) (unifipoller_device_uplink_latency_seconds{site_name=~\"$Site\", name=~\"$Gateway\"})",
+              "expr": "sum by (name) (unpoller_device_uplink_latency_seconds{site_name=~\"$Site\", name=~\"$Gateway\"})",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{name}} Uplink Latency",
@@ -711,14 +711,14 @@
           },
           "targets": [
             {
-              "expr": "unifipoller_device_cpu_utilization_ratio{site_name=~\"$Site\", name=~\"$Gateway\"}",
+              "expr": "unpoller_device_cpu_utilization_ratio{site_name=~\"$Site\", name=~\"$Gateway\"}",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{name}} CPU %",
               "refId": "A"
             },
             {
-              "expr": "unifipoller_device_memory_utilization_ratio{site_name=~\"$Site\", name=~\"$Gateway\"}",
+              "expr": "unpoller_device_memory_utilization_ratio{site_name=~\"$Site\", name=~\"$Gateway\"}",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{name}} RAM %",
@@ -804,10 +804,10 @@
             "lineColor": "rgb(31, 120, 193)",
             "show": false
           },
-          "tableColumn": "unifipoller_device_uplink_speed_mbps{instance=\"UniFi-Poller:9130\", job=\"unifipoller\", name=\"gateway\", port=\"all\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\"}",
+          "tableColumn": "unpoller_device_uplink_speed_mbps{instance=\"UniFi-Poller:9130\", job=\"unpoller\", name=\"gateway\", port=\"all\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\"}",
           "targets": [
             {
-              "expr": "unifipoller_device_uplink_speed_mbps{site_name=~\"$Site\", name=~\"$Gateway\"}",
+              "expr": "unpoller_device_uplink_speed_mbps{site_name=~\"$Site\", name=~\"$Gateway\"}",
               "instant": true,
               "refId": "A"
             }
@@ -898,10 +898,10 @@
             "lineColor": "rgb(31, 120, 193)",
             "show": true
           },
-          "tableColumn": "unifipoller_device_stations{instance=\"UniFi-Poller:9130\", job=\"unifipoller\", name=\"gateway\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\", station_type=\"desktop\", type=\"ugw\"}",
+          "tableColumn": "unpoller_device_stations{instance=\"UniFi-Poller:9130\", job=\"unpoller\", name=\"gateway\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\", station_type=\"desktop\", type=\"ugw\"}",
           "targets": [
             {
-              "expr": "unifipoller_device_stations{site_name=~\"$Site\", name=~\"$Gateway\",station_type=\"desktop\"}",
+              "expr": "unpoller_device_stations{site_name=~\"$Site\", name=~\"$Gateway\",station_type=\"desktop\"}",
               "instant": true,
               "interval": "$Smooth",
               "refId": "A"
@@ -993,10 +993,10 @@
             "lineColor": "rgb(31, 120, 193)",
             "show": true
           },
-          "tableColumn": "unifipoller_device_stations{instance=\"UniFi-Poller:9130\", job=\"unifipoller\", name=\"gateway\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\", station_type=\"user\", type=\"ugw\"}",
+          "tableColumn": "unpoller_device_stations{instance=\"UniFi-Poller:9130\", job=\"unpoller\", name=\"gateway\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\", station_type=\"user\", type=\"ugw\"}",
           "targets": [
             {
-              "expr": "unifipoller_device_stations{site_name=~\"$Site\", name=~\"$Gateway\",station_type=\"user\"}",
+              "expr": "unpoller_device_stations{site_name=~\"$Site\", name=~\"$Gateway\",station_type=\"user\"}",
               "instant": true,
               "refId": "A"
             }
@@ -1087,10 +1087,10 @@
             "lineColor": "rgb(31, 120, 193)",
             "show": true
           },
-          "tableColumn": "unifipoller_device_stations{instance=\"UniFi-Poller:9130\", job=\"unifipoller\", name=\"gateway\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\", station_type=\"mobile\", type=\"ugw\"}",
+          "tableColumn": "unpoller_device_stations{instance=\"UniFi-Poller:9130\", job=\"unpoller\", name=\"gateway\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\", station_type=\"mobile\", type=\"ugw\"}",
           "targets": [
             {
-              "expr": "unifipoller_device_stations{site_name=~\"$Site\", name=~\"$Gateway\",station_type=\"mobile\"}",
+              "expr": "unpoller_device_stations{site_name=~\"$Site\", name=~\"$Gateway\",station_type=\"mobile\"}",
               "instant": true,
               "interval": "$Smooth",
               "refId": "A"
@@ -1182,10 +1182,10 @@
             "lineColor": "rgb(31, 120, 193)",
             "show": true
           },
-          "tableColumn": "unifipoller_device_stations{instance=\"UniFi-Poller:9130\", job=\"unifipoller\", name=\"gateway\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\", station_type=\"guest\", type=\"ugw\"}",
+          "tableColumn": "unpoller_device_stations{instance=\"UniFi-Poller:9130\", job=\"unpoller\", name=\"gateway\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\", station_type=\"guest\", type=\"ugw\"}",
           "targets": [
             {
-              "expr": "unifipoller_device_stations{site_name=~\"$Site\", name=~\"$Gateway\",station_type=\"guest\"}",
+              "expr": "unpoller_device_stations{site_name=~\"$Site\", name=~\"$Gateway\",station_type=\"guest\"}",
               "instant": true,
               "refId": "A"
             }
@@ -1276,10 +1276,10 @@
             "lineColor": "rgb(31, 120, 193)",
             "show": true
           },
-          "tableColumn": "unifipoller_device_stations{instance=\"UniFi-Poller:9130\", job=\"unifipoller\", name=\"gateway\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\", station_type=\"handheld\", type=\"ugw\"}",
+          "tableColumn": "unpoller_device_stations{instance=\"UniFi-Poller:9130\", job=\"unpoller\", name=\"gateway\", site_name=\"Home (default)\", source=\"https://unifi-controller:8443\", station_type=\"handheld\", type=\"ugw\"}",
           "targets": [
             {
-              "expr": "unifipoller_device_stations{site_name=~\"$Site\", name=~\"$Gateway\",station_type=\"handheld\"}",
+              "expr": "unpoller_device_stations{site_name=~\"$Site\", name=~\"$Gateway\",station_type=\"handheld\"}",
               "instant": true,
               "interval": "$Smooth",
               "refId": "A"
@@ -1370,20 +1370,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "unifipoller_device_load_average_1{site_name=~\"$Site\", name=~\"$Gateway\"}",
+              "expr": "unpoller_device_load_average_1{site_name=~\"$Site\", name=~\"$Gateway\"}",
               "interval": "$Smooth",
               "legendFormat": "{{name}} load1",
               "refId": "A"
             },
             {
-              "expr": "unifipoller_device_load_average_5{site_name=~\"$Site\", name=~\"$Gateway\"}",
+              "expr": "unpoller_device_load_average_5{site_name=~\"$Site\", name=~\"$Gateway\"}",
               "hide": true,
               "interval": "$Smooth",
               "legendFormat": "{{name}} load5",
               "refId": "B"
             },
             {
-              "expr": "unifipoller_device_load_average_15{site_name=~\"$Site\", name=~\"$Gateway\"}",
+              "expr": "unpoller_device_load_average_15{site_name=~\"$Site\", name=~\"$Gateway\"}",
               "interval": "$Smooth",
               "legendFormat": "{{name}} load15",
               "refId": "C"
@@ -1500,26 +1500,26 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_device_wan_receive_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Bytes Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unifipoller_device_wan_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Bytes Tx",
               "refId": "B"
             },
             {
-              "expr": "unifipoller_device_wan_transmit_rate_bytes{site_name=~\"$Site\", name=~\"$Gateway\"}",
+              "expr": "unpoller_device_wan_transmit_rate_bytes{site_name=~\"$Site\", name=~\"$Gateway\"}",
               "hide": true,
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Bytes Tx",
               "refId": "C"
             },
             {
-              "expr": "unifipoller_device_wan_receive_rate_bytes{site_name=~\"$Site\", name=~\"$Gateway\"}",
+              "expr": "unpoller_device_wan_receive_rate_bytes{site_name=~\"$Site\", name=~\"$Gateway\"}",
               "hide": true,
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Bytes Rx",
@@ -1637,13 +1637,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_device_lan_receive_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_lan_receive_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Bytes Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unifipoller_device_lan_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_lan_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Bytes Tx",
               "refId": "B"
@@ -1763,13 +1763,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_device_wan_receive_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Packets Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unifipoller_device_wan_transmit_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Packets Tx",
               "refId": "B"
@@ -1890,13 +1890,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_device_lan_receive_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_lan_receive_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Packets Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unifipoller_device_lan_transmit_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_lan_transmit_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Packets Tx",
               "refId": "B"
@@ -2018,25 +2018,25 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_device_wan_transmit_broadcast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_broadcast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Broadcast Tx",
               "refId": "D"
             },
             {
-              "expr": "rate(unifipoller_device_wan_receive_broadcast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_broadcast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Broadcast Rx",
               "refId": "C"
             },
             {
-              "expr": "rate(unifipoller_device_wan_receive_multicast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_multicast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}}  Multicast Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unifipoller_device_wan_transmit_multicast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_multicast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Multicast Tx",
               "refId": "B"
@@ -2158,25 +2158,25 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_device_wan_transmit_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Drops Tx",
               "refId": "A"
             },
             {
-              "expr": "rate(unifipoller_device_wan_receive_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Drops Rx",
               "refId": "B"
             },
             {
-              "expr": "rate(unifipoller_device_wan_transmit_errors_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_errors_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Errors Tx",
               "refId": "C"
             },
             {
-              "expr": "rate(unifipoller_device_wan_receive_errors_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_errors_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Errors Rx",
               "refId": "D"
@@ -2295,7 +2295,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_device_lan_receive_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_lan_receive_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
               "hide": false,
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Dropped Rx",
@@ -2380,14 +2380,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_device_info{type=~\"udm|usg|ugw\"},source)",
+        "definition": "label_values(unpoller_device_info{type=~\"udm|usg|ugw\"},source)",
         "hide": 2,
         "includeAll": true,
         "label": "",
         "multi": true,
         "name": "Controller",
         "options": [],
-        "query": "label_values(unifipoller_device_info{type=~\"udm|usg|ugw\"},source)",
+        "query": "label_values(unpoller_device_info{type=~\"udm|usg|ugw\"},source)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -2402,14 +2402,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_device_info{source=~\"$Controller\", type=~\"udm|usg|ugw\"},site_name)",
+        "definition": "label_values(unpoller_device_info{source=~\"$Controller\", type=~\"udm|usg|ugw\"},site_name)",
         "hide": 0,
         "includeAll": true,
         "label": "",
         "multi": true,
         "name": "Site",
         "options": [],
-        "query": "label_values(unifipoller_device_info{source=~\"$Controller\", type=~\"udm|usg|ugw\"},site_name)",
+        "query": "label_values(unpoller_device_info{source=~\"$Controller\", type=~\"udm|usg|ugw\"},site_name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -2424,14 +2424,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_device_info{site_name=~\"$Site\", type=~\"udm|usg|ugw\"},name)",
+        "definition": "label_values(unpoller_device_info{site_name=~\"$Site\", type=~\"udm|usg|ugw\"},name)",
         "hide": 2,
         "includeAll": true,
         "label": "",
         "multi": true,
         "name": "Gateway",
         "options": [],
-        "query": "label_values(unifipoller_device_info{site_name=~\"$Site\", type=~\"udm|usg|ugw\"},name)",
+        "query": "label_values(unpoller_device_info{site_name=~\"$Site\", type=~\"udm|usg|ugw\"},name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/v2.0.0/UniFi-Poller_ USW Insights - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ USW Insights - Prometheus.json
@@ -367,7 +367,7 @@
       ],
       "targets": [
         {
-          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unifipoller_device_info{site_name=~\"$Site\", name=~\"$Switch\"})",
+          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unpoller_device_info{site_name=~\"$Site\", name=~\"$Switch\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -375,7 +375,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unifipoller_device_uptime_seconds{site_name=~\"$Site\", name=~\"$Switch\"})",
+          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unpoller_device_uptime_seconds{site_name=~\"$Site\", name=~\"$Switch\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -383,7 +383,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unifipoller_device_bytes_total{site_name=~\"$Site\", name=~\"$Switch\"})",
+          "expr": "sum by (ip,mac,model,name,serial,site_name,type,version,source) (unpoller_device_bytes_total{site_name=~\"$Site\", name=~\"$Switch\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -458,13 +458,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (name,temp_area,temp_type) (unifipoller_device_temperature_celsius{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,temp_area,temp_type) (unpoller_device_temperature_celsius{site_name=~\"$Site\",name=~\"$Switch\"})",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{temp_area}} {{temp_type}} C ",
           "refId": "A"
         },
         {
-          "expr": "sum by (name,temp_area,temp_type) (unifipoller_device_temperature_celsius{site_name=~\"$Site\",name=~\"$Switch\"}*9/5+32)",
+          "expr": "sum by (name,temp_area,temp_type) (unpoller_device_temperature_celsius{site_name=~\"$Site\",name=~\"$Switch\"}*9/5+32)",
           "hide": false,
           "instant": false,
           "interval": "$Smooth",
@@ -573,7 +573,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "unifipoller_device_memory_utilization_ratio{type=\"usw\", site_name=~\"$Site\",name=~\"$Switch\",type=~\"usw|udm|udmp\"}",
+          "expr": "unpoller_device_memory_utilization_ratio{type=\"usw\", site_name=~\"$Site\",name=~\"$Switch\",type=~\"usw|udm|udmp\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}}",
           "refId": "A"
@@ -692,20 +692,20 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "unifipoller_device_load_average_1{site_name=~\"$Site\",name=~\"$Switch\"}",
+          "expr": "unpoller_device_load_average_1{site_name=~\"$Site\",name=~\"$Switch\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}} load1",
           "refId": "A"
         },
         {
-          "expr": "unifipoller_device_load_average_5{site_name=~\"$Site\",name=~\"$Switch\"}",
+          "expr": "unpoller_device_load_average_5{site_name=~\"$Site\",name=~\"$Switch\"}",
           "hide": true,
           "interval": "$Smooth",
           "legendFormat": "{{name}} load5",
           "refId": "B"
         },
         {
-          "expr": "unifipoller_device_load_average_15{site_name=~\"$Site\",name=~\"$Switch\"}",
+          "expr": "unpoller_device_load_average_15{site_name=~\"$Site\",name=~\"$Switch\"}",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "{{name}} load15",
@@ -813,7 +813,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "unifipoller_device_cpu_utilization_ratio{site_name=~\"$Site\",name=~\"$Switch\",type=~\"usw|udm|udmp\"}",
+          "expr": "unpoller_device_cpu_utilization_ratio{site_name=~\"$Site\",name=~\"$Switch\",type=~\"usw|udm|udmp\"}",
           "interval": "$Smooth",
           "legendFormat": "{{name}}",
           "refId": "A"
@@ -921,13 +921,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(unifipoller_device_port_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Switch\", port_id=~\"$Port\"}[$__interval])",
+          "expr": "rate(unpoller_device_port_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Switch\", port_id=~\"$Port\"}[$__interval])",
           "interval": "$Smooth",
           "legendFormat": "{{port_id}} {{port_name}} Tx",
           "refId": "A"
         },
         {
-          "expr": "rate(unifipoller_device_port_receive_bytes_total{site_name=~\"$Site\", name=~\"$Switch\", port_id=~\"$Port\"}[$__interval])",
+          "expr": "rate(unpoller_device_port_receive_bytes_total{site_name=~\"$Site\", name=~\"$Switch\", port_id=~\"$Port\"}[$__interval])",
           "interval": "$Smooth",
           "legendFormat": "{{port_id}} {{port_name}} Rx",
           "refId": "B"
@@ -1413,90 +1413,90 @@
       ],
       "targets": [
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_receive_bytes_total{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_receive_bytes_total{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "instant": true,
           "refId": "A"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_transmit_bytes_total{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_transmit_bytes_total{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
           "refId": "B"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_receive_dropped_total{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_receive_dropped_total{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
           "refId": "D"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_transmit_dropped_total{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_transmit_dropped_total{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
           "refId": "C"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_receive_broadcast_total{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_receive_broadcast_total{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
           "refId": "F"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_transmit_broadcast_total{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_transmit_broadcast_total{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
           "refId": "E"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_receive_errors_total{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_receive_errors_total{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
           "refId": "H"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_transmit_errors_total{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_transmit_errors_total{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
           "refId": "G"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_receive_packets_total{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_receive_packets_total{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
           "refId": "J"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_transmit_packets_total{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_transmit_packets_total{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
           "refId": "I"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_poe_amperes{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_poe_amperes{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
           "refId": "K"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_poe_volts{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_poe_volts{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
           "refId": "L"
         },
         {
-          "expr": "sum by (name,port_num,port_name,site_name,source) (unifipoller_device_port_poe_watts{site_name=~\"$Site\",name=~\"$Switch\"})",
+          "expr": "sum by (name,port_num,port_name,site_name,source) (unpoller_device_port_poe_watts{site_name=~\"$Site\",name=~\"$Switch\"})",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1710,7 +1710,7 @@
           ],
           "targets": [
             {
-              "expr": "unifipoller_device_port_port_speed_bps{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_port_speed_bps{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "instant": true,
               "interval": "$Smooth",
@@ -1718,7 +1718,7 @@
               "refId": "A"
             },
             {
-              "expr": "unifipoller_device_port_poe_amperes{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_poe_amperes{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "hide": false,
               "instant": true,
@@ -1727,7 +1727,7 @@
               "refId": "B"
             },
             {
-              "expr": "unifipoller_device_port_poe_volts{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_poe_volts{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "hide": false,
               "instant": true,
@@ -1736,7 +1736,7 @@
               "refId": "C"
             },
             {
-              "expr": "unifipoller_device_port_poe_watts{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_poe_watts{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "hide": false,
               "instant": true,
@@ -1745,7 +1745,7 @@
               "refId": "D"
             },
             {
-              "expr": "unifipoller_device_port_transmit_broadcast_total{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_transmit_broadcast_total{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "instant": true,
               "interval": "$Smooth",
@@ -1753,7 +1753,7 @@
               "refId": "E"
             },
             {
-              "expr": "unifipoller_device_port_transmit_multicast_total{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_transmit_multicast_total{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "instant": true,
               "interval": "$Smooth",
@@ -1761,7 +1761,7 @@
               "refId": "F"
             },
             {
-              "expr": "unifipoller_device_port_receive_dropped_total{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_receive_dropped_total{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "instant": true,
               "interval": "$Smooth",
@@ -1769,7 +1769,7 @@
               "refId": "G"
             },
             {
-              "expr": "unifipoller_device_port_transmit_dropped_total{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_transmit_dropped_total{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "instant": true,
               "interval": "$Smooth",
@@ -1777,7 +1777,7 @@
               "refId": "N"
             },
             {
-              "expr": "unifipoller_device_port_transmit_errors_total+unifipoller_device_port_receive_errors_total{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_transmit_errors_total+unpoller_device_port_receive_errors_total{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "instant": true,
               "interval": "$Smooth",
@@ -1785,7 +1785,7 @@
               "refId": "H"
             },
             {
-              "expr": "unifipoller_device_port_receive_packets_total{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_receive_packets_total{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "instant": true,
               "interval": "$Smooth",
@@ -1793,7 +1793,7 @@
               "refId": "I"
             },
             {
-              "expr": "unifipoller_device_port_transmit_packets_total{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_transmit_packets_total{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "hide": false,
               "instant": true,
@@ -1802,7 +1802,7 @@
               "refId": "J"
             },
             {
-              "expr": "unifipoller_device_port_receive_bytes_total{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_receive_bytes_total{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "hide": false,
               "instant": true,
@@ -1811,7 +1811,7 @@
               "refId": "K"
             },
             {
-              "expr": "unifipoller_device_port_transmit_bytes_total{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_transmit_bytes_total{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "hide": false,
               "instant": true,
@@ -1820,7 +1820,7 @@
               "refId": "L"
             },
             {
-              "expr": "unifipoller_device_port_satisfaction_percent{port_id=\"$Port\", site_name=~\"$Site\"}",
+              "expr": "unpoller_device_port_satisfaction_percent{port_id=\"$Port\", site_name=~\"$Site\"}",
               "format": "time_series",
               "hide": false,
               "instant": true,
@@ -1894,13 +1894,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_device_port_receive_bytes_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_bytes_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": " {{port_id}} ({{port_name}}) Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unifipoller_device_port_transmit_bytes_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_bytes_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": " {{port_id}} ({{port_name}}) Tx",
               "refId": "B"
@@ -2008,25 +2008,25 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_device_port_receive_broadcast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_broadcast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Broadcast Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unifipoller_device_port_transmit_broadcast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_broadcast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Broadcast Tx",
               "refId": "B"
             },
             {
-              "expr": "rate(unifipoller_device_port_receive_multicast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_multicast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Multicast Rx",
               "refId": "C"
             },
             {
-              "expr": "rate(unifipoller_device_port_transmit_multicast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_multicast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Multicast Tx",
               "refId": "D"
@@ -2136,25 +2136,25 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_device_port_receive_dropped_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_dropped_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Drops Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unifipoller_device_port_transmit_dropped_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_dropped_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Drops Tx",
               "refId": "B"
             },
             {
-              "expr": "rate(unifipoller_device_port_transmit_errors_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_errors_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Errors Tx",
               "refId": "C"
             },
             {
-              "expr": "rate(unifipoller_device_port_receive_errors_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_errors_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Errors Rx",
               "refId": "D"
@@ -2265,13 +2265,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unifipoller_device_port_receive_packets_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_packets_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unifipoller_device_port_transmit_packets_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_packets_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Tx",
               "refId": "B"
@@ -2374,7 +2374,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "unifipoller_device_port_poe_watts{site_name=~\"$Site\", port_id=~\"$Port\"}",
+              "expr": "unpoller_device_port_poe_watts{site_name=~\"$Site\", port_id=~\"$Port\"}",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}}  Watts",
               "refId": "A"
@@ -2478,7 +2478,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "unifipoller_device_port_poe_volts{site_name=~\"$Site\", port_id=~\"$Port\"}",
+              "expr": "unpoller_device_port_poe_volts{site_name=~\"$Site\", port_id=~\"$Port\"}",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} Volts",
               "refId": "A"
@@ -2581,7 +2581,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "unifipoller_device_port_poe_amperes{site_name=~\"$Site\", port_id=~\"$Port\"}",
+              "expr": "unpoller_device_port_poe_amperes{site_name=~\"$Site\", port_id=~\"$Port\"}",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} Amps",
               "refId": "A"
@@ -2662,14 +2662,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_device_info,source)",
+        "definition": "label_values(unpoller_device_info,source)",
         "hide": 2,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Controller",
         "options": [],
-        "query": "label_values(unifipoller_device_info,source)",
+        "query": "label_values(unpoller_device_info,source)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -2726,14 +2726,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_device_info{source=~\"$Controller\"},site_name)",
+        "definition": "label_values(unpoller_device_info{source=~\"$Controller\"},site_name)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Site",
         "options": [],
-        "query": "label_values(unifipoller_device_info{source=~\"$Controller\"},site_name)",
+        "query": "label_values(unpoller_device_info{source=~\"$Controller\"},site_name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -2748,14 +2748,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_device_info{site_name=~\"$Site\", type=~\"$Devices\"},name)",
+        "definition": "label_values(unpoller_device_info{site_name=~\"$Site\", type=~\"$Devices\"},name)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Switch",
         "options": [],
-        "query": "label_values(unifipoller_device_info{site_name=~\"$Site\", type=~\"$Devices\"},name)",
+        "query": "label_values(unpoller_device_info{site_name=~\"$Site\", type=~\"$Devices\"},name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -2770,14 +2770,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(unifipoller_device_port_port_speed_bps{site_name=~\"$Site\", name=~\"$Switch\"},port_id)",
+        "definition": "label_values(unpoller_device_port_port_speed_bps{site_name=~\"$Site\", name=~\"$Switch\"},port_id)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Port",
         "options": [],
-        "query": "label_values(unifipoller_device_port_port_speed_bps{site_name=~\"$Site\", name=~\"$Switch\"},port_id)",
+        "query": "label_values(unpoller_device_port_port_speed_bps{site_name=~\"$Site\", name=~\"$Switch\"},port_id)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
This PR fixes two bugs that I'm seeing using a brand new install of unpoller v2.7.5 (Docker) and Prometheus v2.41.0, along with Grafana v8.5.0 (Docker):

1. unpoller is sending metrics to Prometheus prefixed with ``unpoller_``, not ``unifipoller_``. The dashboards all expect the latter, so they show no data. A simple `s/unifipoller/unpoller/g` on the Prometheus JSON files fixes this.
2. The `grafana-piechart-panel` plugin no longer exists, so all of those dashboard elements can't be found. This is now the `piechart` core plugin. Once again, `s/grafana-piechart-panel/piechart/g` on the JSON files fixes this.