### PR TITLE
Fix $Site parameter in Influx dashboards for newer versions of Grafana

### DIFF
--- a/v2.0.0/UniFi-Poller_ Client DPI - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ Client DPI - InfluxDB.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_UNIFI_POLLER",
-      "label": "UniFi Poller",
+      "label": "Unpoller",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -60,7 +60,7 @@
       }
     ]
   },
-  "description": "UniFi Poller v2.0 Displays DPI information for clients in a UniFi network using InfluxDB.",
+  "description": "Unpoller v2.9  Displays DPI information for clients in a UniFi network using InfluxDB.",
   "editable": true,
   "gnetId": 11315,
   "graphTooltip": 1,
@@ -75,7 +75,7 @@
       "tags": [
         "unifi-poller"
       ],
-      "title": "UniFi Poller",
+      "title": "Unpoller",
       "type": "dashboards"
     },
     {
@@ -326,7 +326,7 @@
           "measurement": "clientdpi",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"rx_bytes\") AS \"Bytes Rx Total\", last(\"tx_bytes\") AS \"Bytes Tx Total\" FROM \"clientdpi\" WHERE (\"site_name\" =~ /^$Site$/ AND \"name\" = 'TOTAL' AND \"category\" =~ /^$Category$/ AND \"application\" = 'TOTAL' AND \"mac\" = 'TOTAL') AND $timeFilter GROUP BY \"site_name\", \"category\", \"source\", \"application\", \"name\", \"mac\"",
+          "query": "SELECT last(\"rx_bytes\") AS \"Bytes Rx Total\", last(\"tx_bytes\") AS \"Bytes Tx Total\" FROM \"clientdpi\" WHERE (\"site_name\" =~ /^${Site:regex}$/ AND \"name\" = 'TOTAL' AND \"category\" =~ /^${Category:regex}$/ AND \"application\" = 'TOTAL' AND \"mac\" = 'TOTAL') AND $timeFilter GROUP BY \"site_name\", \"category\", \"source\", \"application\", \"name\", \"mac\"",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "table",
@@ -444,7 +444,7 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
@@ -456,7 +456,7 @@
               "condition": "AND",
               "key": "category",
               "operator": "=~",
-              "value": "/^$Category$/"
+              "value": "/^${Category:regex}$/"
             },
             {
               "condition": "AND",
@@ -538,7 +538,7 @@
           "measurement": "clientdpi",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"rx_bytes\")+last(\"tx_bytes\") FROM \"clientdpi\" WHERE (\"category\" =~ /^$Category$/ AND \"source\" =~ /^$Controller$/ AND \"site_name\" =~ /^$Site$/ AND \"name\" =~ /^$Client$/ AND \"application\" != 'TOTAL') AND $timeFilter GROUP BY \"application\", \"category\"",
+          "query": "SELECT last(\"rx_bytes\")+last(\"tx_bytes\") FROM \"clientdpi\" WHERE (\"category\" =~ /^${Category:regex}$/ AND \"source\" =~ /^${Controller:regex}$/ AND \"site_name\" =~ /^${Site:regex}$/ AND \"name\" =~ /^${Client:regex}$/ AND \"application\" != 'TOTAL') AND $timeFilter GROUP BY \"application\", \"category\"",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -560,25 +560,25 @@
             {
               "key": "category",
               "operator": "=~",
-              "value": "/^$Category$/"
+              "value": "/^${Category:regex}$/"
             },
             {
               "condition": "AND",
               "key": "source",
               "operator": "=~",
-              "value": "/^$Controller$/"
+              "value": "/^${Controller:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Client$/"
+              "value": "/^${Client:regex}$/"
             },
             {
               "condition": "AND",
@@ -628,25 +628,25 @@
             {
               "key": "category",
               "operator": "=~",
-              "value": "/^$Category$/"
+              "value": "/^${Category:regex}$/"
             },
             {
               "condition": "AND",
               "key": "source",
               "operator": "=~",
-              "value": "/^$Controller$/"
+              "value": "/^${Controller:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Client$/"
+              "value": "/^${Client:regex}$/"
             },
             {
               "condition": "AND",
@@ -722,7 +722,7 @@
           "measurement": "clientdpi",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"rx_bytes\")+last(\"tx_bytes\") FROM \"clientdpi\" WHERE (\"category\" =~ /^$Category$/ AND \"source\" =~ /^$Controller$/ AND \"site_name\" =~ /^$Site$/ AND \"name\" =~ /^$Client$/ AND \"application\" = 'TOTAL') AND $timeFilter GROUP BY \"application\", \"category\"",
+          "query": "SELECT last(\"rx_bytes\")+last(\"tx_bytes\") FROM \"clientdpi\" WHERE (\"category\" =~ /^${Category:regex}$/ AND \"source\" =~ /^${Controller:regex}$/ AND \"site_name\" =~ /^${Site:regex}$/ AND \"name\" =~ /^${Client:regex}$/ AND \"application\" = 'TOTAL') AND $timeFilter GROUP BY \"application\", \"category\"",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -744,25 +744,25 @@
             {
               "key": "category",
               "operator": "=~",
-              "value": "/^$Category$/"
+              "value": "/^${Category:regex}$/"
             },
             {
               "condition": "AND",
               "key": "source",
               "operator": "=~",
-              "value": "/^$Controller$/"
+              "value": "/^${Controller:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Client$/"
+              "value": "/^${Client:regex}$/"
             },
             {
               "condition": "AND",
@@ -812,25 +812,25 @@
             {
               "key": "category",
               "operator": "=~",
-              "value": "/^$Category$/"
+              "value": "/^${Category:regex}$/"
             },
             {
               "condition": "AND",
               "key": "source",
               "operator": "=~",
-              "value": "/^$Controller$/"
+              "value": "/^${Controller:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Client$/"
+              "value": "/^${Client:regex}$/"
             },
             {
               "condition": "AND",
@@ -986,25 +986,25 @@
             {
               "key": "category",
               "operator": "=~",
-              "value": "/^$Category$/"
+              "value": "/^${Category:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "source",
               "operator": "=~",
-              "value": "/^$Controller$/"
+              "value": "/^${Controller:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Client$/"
+              "value": "/^${Client:regex}$/"
             },
             {
               "condition": "AND",
@@ -1195,25 +1195,25 @@
             {
               "key": "category",
               "operator": "=~",
-              "value": "/^$Category$/"
+              "value": "/^${Category:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "source",
               "operator": "=~",
-              "value": "/^$Controller$/"
+              "value": "/^${Controller:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Client$/"
+              "value": "/^${Client:regex}$/"
             },
             {
               "condition": "AND",
@@ -1413,25 +1413,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -1622,25 +1622,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -1831,25 +1831,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -2040,25 +2040,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -2249,25 +2249,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -2458,25 +2458,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -2667,25 +2667,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -2876,25 +2876,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -3085,25 +3085,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -3294,25 +3294,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -3503,25 +3503,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -3712,25 +3712,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -3921,25 +3921,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -4130,25 +4130,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -4339,25 +4339,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -4548,25 +4548,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -4757,25 +4757,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -4966,25 +4966,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -5175,25 +5175,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -5384,25 +5384,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -5593,25 +5593,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -5802,25 +5802,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -6011,25 +6011,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -6220,25 +6220,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -6429,25 +6429,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -6638,25 +6638,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -6847,25 +6847,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -7056,25 +7056,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -7265,25 +7265,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -7474,25 +7474,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -7683,25 +7683,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -7892,25 +7892,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -8101,25 +8101,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -8310,25 +8310,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -8519,25 +8519,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -8728,25 +8728,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -8937,25 +8937,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -9146,25 +9146,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -9355,25 +9355,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -9564,25 +9564,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -9773,25 +9773,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -9982,25 +9982,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -10191,25 +10191,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -10400,25 +10400,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -10609,25 +10609,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -10818,25 +10818,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -11027,25 +11027,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -11236,25 +11236,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -11445,25 +11445,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -11654,25 +11654,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -11863,25 +11863,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -12072,25 +12072,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -12281,25 +12281,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -12490,25 +12490,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -12699,25 +12699,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -12908,25 +12908,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -13117,25 +13117,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -13326,25 +13326,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -13535,25 +13535,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -13744,25 +13744,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -13953,25 +13953,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -14162,25 +14162,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -14371,25 +14371,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -14580,25 +14580,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -14789,25 +14789,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -14998,25 +14998,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -15207,25 +15207,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -15416,25 +15416,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -15625,25 +15625,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -15834,25 +15834,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -16043,25 +16043,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -16252,25 +16252,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -16461,25 +16461,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -16670,25 +16670,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -16879,25 +16879,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -17088,25 +17088,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -17297,25 +17297,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -17506,25 +17506,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -17715,25 +17715,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -17924,25 +17924,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -18133,25 +18133,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -18342,25 +18342,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -18551,25 +18551,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -18773,25 +18773,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -18982,25 +18982,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -19191,25 +19191,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -19400,25 +19400,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -19609,25 +19609,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -19818,25 +19818,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -20027,25 +20027,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -20236,25 +20236,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -20445,25 +20445,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -20654,25 +20654,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -20863,25 +20863,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -21072,25 +21072,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -21281,25 +21281,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -21490,25 +21490,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -21699,25 +21699,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -21908,25 +21908,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -22117,25 +22117,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -22326,25 +22326,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -22535,25 +22535,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -22744,25 +22744,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -22953,25 +22953,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -23162,25 +23162,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -23371,25 +23371,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -23580,25 +23580,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -23789,25 +23789,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -23998,25 +23998,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -24207,25 +24207,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -24416,25 +24416,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -24625,25 +24625,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -24834,25 +24834,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -25043,25 +25043,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -25252,25 +25252,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -25461,25 +25461,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -25670,25 +25670,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -25879,25 +25879,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -26088,25 +26088,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -26297,25 +26297,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -26506,25 +26506,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -26715,25 +26715,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -26924,25 +26924,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -27133,25 +27133,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -27342,25 +27342,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -27551,25 +27551,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -27760,25 +27760,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -27969,25 +27969,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -28178,25 +28178,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -28387,25 +28387,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -28596,25 +28596,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -28805,25 +28805,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -29014,25 +29014,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -29223,25 +29223,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -29432,25 +29432,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -29641,25 +29641,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -29850,25 +29850,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -30059,25 +30059,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -30268,25 +30268,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -30477,25 +30477,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -30686,25 +30686,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -30895,25 +30895,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -31104,25 +31104,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -31313,25 +31313,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -31522,25 +31522,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -31731,25 +31731,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -31940,25 +31940,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -32149,25 +32149,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -32358,25 +32358,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -32567,25 +32567,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -32776,25 +32776,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -32985,25 +32985,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -33194,25 +33194,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -33403,25 +33403,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -33612,25 +33612,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -33821,25 +33821,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -34030,25 +34030,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -34239,25 +34239,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -34448,25 +34448,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -34657,25 +34657,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -34866,25 +34866,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -35075,25 +35075,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -35284,25 +35284,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -35493,25 +35493,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -35702,25 +35702,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -35911,25 +35911,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -36120,25 +36120,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -36329,25 +36329,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -36538,25 +36538,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -36747,25 +36747,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -36956,25 +36956,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -37165,25 +37165,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -37374,25 +37374,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -37583,25 +37583,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -37792,25 +37792,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -38001,25 +38001,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -38210,25 +38210,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -38419,25 +38419,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -38628,25 +38628,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -38837,25 +38837,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -39046,25 +39046,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -39255,25 +39255,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -39464,25 +39464,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -39673,25 +39673,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -39882,25 +39882,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -40091,25 +40091,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -40300,25 +40300,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -40509,25 +40509,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -40718,25 +40718,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -40927,25 +40927,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -41136,25 +41136,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -41345,25 +41345,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -41554,25 +41554,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -41763,25 +41763,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -41972,25 +41972,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -42181,25 +42181,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -42390,25 +42390,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -42599,25 +42599,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -42808,25 +42808,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -43017,25 +43017,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -43226,25 +43226,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -43448,25 +43448,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -43657,25 +43657,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -43866,25 +43866,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -44075,25 +44075,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -44284,25 +44284,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -44493,25 +44493,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -44702,25 +44702,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -44911,25 +44911,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -45120,25 +45120,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -45329,25 +45329,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -45538,25 +45538,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -45747,25 +45747,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -45956,25 +45956,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -46165,25 +46165,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -46374,25 +46374,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -46583,25 +46583,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -46792,25 +46792,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -47001,25 +47001,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -47210,25 +47210,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -47419,25 +47419,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -47628,25 +47628,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -47837,25 +47837,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -48046,25 +48046,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -48255,25 +48255,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -48464,25 +48464,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -48673,25 +48673,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -48882,25 +48882,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -49091,25 +49091,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -49300,25 +49300,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -49509,25 +49509,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -49718,25 +49718,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -49927,25 +49927,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -50136,25 +50136,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -50345,25 +50345,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -50554,25 +50554,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -50763,25 +50763,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -50972,25 +50972,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -51181,25 +51181,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -51390,25 +51390,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -51599,25 +51599,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -51815,25 +51815,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -52018,25 +52018,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -52221,25 +52221,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -52424,25 +52424,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -52627,25 +52627,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -52830,25 +52830,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -53033,25 +53033,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -53236,25 +53236,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -53439,25 +53439,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -53642,25 +53642,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -53845,25 +53845,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -54048,25 +54048,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -54251,25 +54251,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -54454,25 +54454,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -54657,25 +54657,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -54860,25 +54860,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -55063,25 +55063,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -55266,25 +55266,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -55469,25 +55469,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -55672,25 +55672,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -55875,25 +55875,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -56078,25 +56078,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -56281,25 +56281,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -56484,25 +56484,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -56687,25 +56687,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -56890,25 +56890,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -57093,25 +57093,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -57296,25 +57296,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -57499,25 +57499,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -57702,25 +57702,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -57905,25 +57905,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -58108,25 +58108,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -58311,25 +58311,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -58514,25 +58514,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -58717,25 +58717,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -58920,25 +58920,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -59123,25 +59123,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -59326,25 +59326,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -59529,25 +59529,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -59732,25 +59732,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -59935,25 +59935,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -60138,25 +60138,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -60341,25 +60341,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -60544,25 +60544,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -60747,25 +60747,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -60950,25 +60950,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -61153,25 +61153,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -61356,25 +61356,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -61559,25 +61559,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -61762,25 +61762,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -61965,25 +61965,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -62168,25 +62168,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -62371,25 +62371,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -62574,25 +62574,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -62777,25 +62777,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -62980,25 +62980,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -63183,25 +63183,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -63386,25 +63386,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -63589,25 +63589,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -63792,25 +63792,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -63995,25 +63995,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -64198,25 +64198,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -64401,25 +64401,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -64604,25 +64604,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -64807,25 +64807,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -65010,25 +65010,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -65213,25 +65213,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -65416,25 +65416,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -65619,25 +65619,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -65822,25 +65822,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -66025,25 +66025,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -66228,25 +66228,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -66431,25 +66431,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -66634,25 +66634,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -66837,25 +66837,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -67040,25 +67040,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -67243,25 +67243,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -67446,25 +67446,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -67649,25 +67649,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -67852,25 +67852,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -68055,25 +68055,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -68258,25 +68258,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -68461,25 +68461,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -68664,25 +68664,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -68867,25 +68867,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -69070,25 +69070,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -69273,25 +69273,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -69476,25 +69476,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -69679,25 +69679,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -69882,25 +69882,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -70085,25 +70085,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -70288,25 +70288,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -70491,25 +70491,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -70694,25 +70694,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -70897,25 +70897,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -71100,25 +71100,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -71303,25 +71303,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -71506,25 +71506,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -71709,25 +71709,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -71912,25 +71912,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -72115,25 +72115,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -72318,25 +72318,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -72521,25 +72521,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -72724,25 +72724,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -72927,25 +72927,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -73130,25 +73130,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -73333,25 +73333,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -73536,25 +73536,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -73739,25 +73739,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -73942,25 +73942,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -74145,25 +74145,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -74348,25 +74348,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -74551,25 +74551,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -74754,25 +74754,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -74957,25 +74957,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -75160,25 +75160,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -75363,25 +75363,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -75566,25 +75566,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -75788,25 +75788,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -75994,25 +75994,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -76183,25 +76183,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -76371,25 +76371,25 @@
                 {
                   "key": "category",
                   "operator": "=~",
-                  "value": "/^$Category$/"
+                  "value": "/^${Category:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "source",
                   "operator": "=~",
-                  "value": "/^$Controller$/"
+                  "value": "/^${Controller:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "name",
                   "operator": "=~",
-                  "value": "/^$Client$/"
+                  "value": "/^${Client:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -76482,14 +76482,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "show tag values from \"clientdpi\" with key=\"site_name\" WHERE source =~ /^$Controller$/",
+        "definition": "show tag values from \"clientdpi\" with key=\"site_name\" WHERE source =~ /^${Controller:regex}$/",
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": true,
         "name": "Site",
         "options": [],
-        "query": "show tag values from \"clientdpi\" with key=\"site_name\" WHERE source =~ /^$Controller$/",
+        "query": "show tag values from \"clientdpi\" with key=\"site_name\" WHERE source =~ /^${Controller:regex}$/",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -76504,14 +76504,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "show tag values from \"clientdpi\" with key=\"name\" WHERE source =~ /^$Controller$/ AND site_name =~ /^$Site$/",
+        "definition": "show tag values from \"clientdpi\" with key=\"name\" WHERE source =~ /^${Controller:regex}$/ AND site_name =~ /^${Site:regex}$/",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Client",
         "options": [],
-        "query": "show tag values from \"clientdpi\" with key=\"name\" WHERE source =~ /^$Controller$/ AND site_name =~ /^$Site$/",
+        "query": "show tag values from \"clientdpi\" with key=\"name\" WHERE source =~ /^${Controller:regex}$/ AND site_name =~ /^${Site:regex}$/",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -76526,14 +76526,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "show tag values from \"clientdpi\" with key=\"category\" WHERE source =~ /^$Controller$/ AND site_name =~ /^$Site$/",
+        "definition": "show tag values from \"clientdpi\" with key=\"category\" WHERE source =~ /^${Controller:regex}$/ AND site_name =~ /^${Site:regex}$/",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Category",
         "options": [],
-        "query": "show tag values from \"clientdpi\" with key=\"category\" WHERE source =~ /^$Controller$/ AND site_name =~ /^$Site$/",
+        "query": "show tag values from \"clientdpi\" with key=\"category\" WHERE source =~ /^${Controller:regex}$/ AND site_name =~ /^${Site:regex}$/",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/v2.0.0/UniFi-Poller_ Client Insights - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ Client Insights - InfluxDB.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_UNIFI_POLLER",
-      "label": "UniFi Poller",
+      "label": "Unpoller",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -60,7 +60,7 @@
       }
     ]
   },
-  "description": "UniFi Poller v2.0.1 Displays detailed information for clients in a UniFi network.",
+  "description": "Unpoller v2.9  Displays detailed information for clients in a UniFi network.",
   "editable": true,
   "gnetId": 10418,
   "graphTooltip": 1,
@@ -75,7 +75,7 @@
       "tags": [
         "unifi-poller"
       ],
-      "title": "UniFi Poller",
+      "title": "Unpoller",
       "type": "dashboards"
     },
     {
@@ -370,7 +370,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"ip\") AS \"Address\", last(\"note\") AS \"Note\", last(\"network\") AS \"Network\" FROM \"clients\" WHERE (\"is_wired\" = 'false' AND \"ap_mac\" =~ /^$AP$/) AND $timeFilter GROUP BY \"mac\", \"oui\", \"channel\", \"radio\", \"name\", \"ap_mac\"",
+          "query": "SELECT last(\"ip\") AS \"Address\", last(\"note\") AS \"Note\", last(\"network\") AS \"Network\" FROM \"clients\" WHERE (\"is_wired\" = 'false' AND \"ap_mac\" =~ /^${AP:regex}$/) AND $timeFilter GROUP BY \"mac\", \"oui\", \"channel\", \"radio\", \"name\", \"ap_mac\"",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "table",
@@ -470,13 +470,13 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -702,7 +702,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"ip\") AS \"Address\", last(\"note\") AS \"Note\", last(\"network\") AS \"Network\" FROM \"clients\" WHERE (\"is_wired\" != 'false' AND \"name\" =~ /^$Client$/ AND \"site_name\" =~ /$Site$/) AND $timeFilter GROUP BY \"sw_port\", \"mac\", \"oui\", \"use_fixedip\", \"name\"",
+          "query": "SELECT last(\"ip\") AS \"Address\", last(\"note\") AS \"Note\", last(\"network\") AS \"Network\" FROM \"clients\" WHERE (\"is_wired\" != 'false' AND \"name\" =~ /^${Client:regex}$/ AND \"site_name\" =~ /^${Site:regex}$/) AND $timeFilter GROUP BY \"sw_port\", \"mac\", \"oui\", \"use_fixedip\", \"name\"",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "table",
@@ -790,13 +790,13 @@
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wired$/"
+              "value": "/^${Wired:regex}$/"
             },
             {
               "condition": "AND",
               "key": "sw_name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         }
@@ -861,7 +861,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND (\"site_name\" =~ /$Site$/ AND \"name\" =~ /^$Wired$/ AND sw_name =~ /$Switch$/ ) GROUP BY \"hostname\"",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND (\"site_name\" =~ /^${Site:regex}$/ AND \"name\" =~ /^${Wired:regex}$/ AND sw_name =~ /^${Switch:regex}$/ ) GROUP BY \"hostname\"",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -904,7 +904,7 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND (\"site_name\" =~ /$Site$/ AND \"name\" =~ /^$Wireless$/ AND ap_name =~ /$AP$/ ) GROUP BY \"channel\"",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND (\"site_name\" =~ /^${Site:regex}$/ AND \"name\" =~ /^${Wireless:regex}$/ AND ap_name =~ /^${AP:regex}$/ ) GROUP BY \"channel\"",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series",
@@ -986,7 +986,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT count(distinct(\"hostname\")) FROM \"clients\" WHERE  $timeFilter  AND \"ap_name\" =~ /$AP$/ AND \"site_name\" =~ /$Site$/  AND \"name\" =~ /^$Wireless$/ GROUP BY radio_proto",
+          "query": "SELECT count(distinct(\"hostname\")) FROM \"clients\" WHERE  $timeFilter  AND \"ap_name\" =~ /^${AP:regex}$/ AND \"site_name\" =~ /^${Site:regex}$/  AND \"name\" =~ /^${Wireless:regex}$/ GROUP BY radio_proto",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1074,7 +1074,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND site_name =~ /$Site$/ AND ((\"name\" =~ /^$Wireless$/ AND \"ap_name\" =~ /^$AP$/) OR (\"name\" =~ /^$Wired$/ AND \"sw_name\" =~ /$Switch$/ )) GROUP BY \"oui\"",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND site_name =~ /^${Site:regex}$/ AND ((\"name\" =~ /^${Wireless:regex}$/ AND \"ap_name\" =~ /^${AP:regex}$/) OR (\"name\" =~ /^${Wired:regex}$/ AND \"sw_name\" =~ /^${Switch:regex}$/ )) GROUP BY \"oui\"",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1160,7 +1160,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND site_name =~ /$Site$/ AND ((\"name\" =~ /^$Wireless$/ AND \"ap_name\" =~ /^$AP$/) OR (\"name\" =~ /^$Wired$/ AND \"sw_name\" =~ /$Switch$/ )) GROUP BY \"os_class\", \"os_name\", \"dev_cat\", \"dev_family\", \"dev_id\"",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND site_name =~ /^${Site:regex}$/ AND ((\"name\" =~ /^${Wireless:regex}$/ AND \"ap_name\" =~ /^${AP:regex}$/) OR (\"name\" =~ /^${Wired:regex}$/ AND \"sw_name\" =~ /^${Switch:regex}$/ )) GROUP BY \"os_class\", \"os_name\", \"dev_cat\", \"dev_family\", \"dev_id\"",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1282,7 +1282,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT derivative(sum(\"wired-rx_bytes\"), 1s) AS \"Rx\", derivative(sum(\"wired-tx_bytes\"), 1s) AS \"Tx\" FROM \"clients\" WHERE (\"name\" !~ /^amazon-|camera|cam$/ AND \"name\" =~ /^$Wired$/ AND \"site_name\" =~ /^$Site$/ AND \"sw_name\" =~ /^$Switch$/) AND $timeFilter GROUP BY time($__interval),\"name\",\"mac\"fill(none)",
+          "query": "SELECT derivative(sum(\"wired-rx_bytes\"), 1s) AS \"Rx\", derivative(sum(\"wired-tx_bytes\"), 1s) AS \"Tx\" FROM \"clients\" WHERE (\"name\" !~ /^amazon-|camera|cam$/ AND \"name\" =~ /^${Wired:regex}$/ AND \"site_name\" =~ /^${Site:regex}$/ AND \"sw_name\" =~ /^${Switch:regex}$/) AND $timeFilter GROUP BY time($__interval),\"name\",\"mac\"fill(none)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1346,19 +1346,19 @@
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wired$/"
+              "value": "/^${Wired:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "sw_name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         }
@@ -1560,19 +1560,19 @@
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -1713,19 +1713,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             }
           ]
         }
@@ -1880,7 +1880,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"ip\" FROM \"clients\" WHERE \"use_fixedip\" != 'true' AND \"name\" =~ /^$Client$/ AND (\"ap_name\" =~ /^$AP$/ OR \"sw_name\" =~ /$Switch$/) AND \"site_name\" =~ /^$Site$/ AND $timeFilter GROUP BY \"name\"",
+          "query": "SELECT \"ip\" FROM \"clients\" WHERE \"use_fixedip\" != 'true' AND \"name\" =~ /^${Client:regex}$/ AND (\"ap_name\" =~ /^${AP:regex}$/ OR \"sw_name\" =~ /^${Switch:regex}$/) AND \"site_name\" =~ /^${Site:regex}$/ AND $timeFilter GROUP BY \"name\"",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1898,19 +1898,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         },
@@ -1934,7 +1934,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"ip\" FROM \"clients\" WHERE \"use_fixedip\" != 'true' AND \"name\" =~ /^$Client$/ AND (\"ap_name\" =~ /^$AP$/ OR \"sw_name\" =~ /$Switch$/) AND \"site_name\" =~ /^$Site$/ AND $timeFilter GROUP BY \"name\"",
+          "query": "SELECT \"ip\" FROM \"clients\" WHERE \"use_fixedip\" != 'true' AND \"name\" =~ /^${Client:regex}$/ AND (\"ap_name\" =~ /^${AP:regex}$/ OR \"sw_name\" =~ /^${Switch:regex}$/) AND \"site_name\" =~ /^${Site:regex}$/ AND $timeFilter GROUP BY \"name\"",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -1952,19 +1952,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wired$/"
+              "value": "/^${Wired:regex}$/"
             },
             {
               "condition": "AND",
               "key": "sw_name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -2179,19 +2179,19 @@
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wired$/"
+              "value": "/^${Wired:regex}$/"
             },
             {
               "condition": "AND",
               "key": "sw_name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         },
@@ -2291,19 +2291,19 @@
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             }
           ]
         }
@@ -2426,7 +2426,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT non_negative_derivative(sum(\"wired-rx_bytes\"), 1s) AS \"Rx\", non_negative_derivative(sum(\"wired-tx_bytes\"), 1s) AS \"Tx\" FROM \"clients\" WHERE \"name\" =~ /camera|cam$/ AND \"site_name\" =~ /^$Site$/ AND (\"sw_name\" =~ /^$Switch$/ OR \"ap_name\" =~ /^$AP$/) AND $timeFilter GROUP BY time($__interval), \"name\", \"mac\"",
+          "query": "SELECT non_negative_derivative(sum(\"wired-rx_bytes\"), 1s) AS \"Rx\", non_negative_derivative(sum(\"wired-tx_bytes\"), 1s) AS \"Tx\" FROM \"clients\" WHERE \"name\" =~ /camera|cam$/ AND \"site_name\" =~ /^${Site:regex}$/ AND (\"sw_name\" =~ /^${Switch:regex}$/ OR \"ap_name\" =~ /^${AP:regex}$/) AND $timeFilter GROUP BY time($__interval), \"name\", \"mac\"",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -2490,19 +2490,19 @@
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "sw_name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             },
             {
               "condition": "OR",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             }
           ]
         }
@@ -2639,19 +2639,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -2789,19 +2789,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -2938,19 +2938,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -3086,19 +3086,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -3241,19 +3241,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -3390,19 +3390,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -3546,19 +3546,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -3696,19 +3696,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -3845,19 +3845,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -3995,19 +3995,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -4146,19 +4146,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -4301,19 +4301,19 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$Wireless$/"
+              "value": "/^${Wireless:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -4396,14 +4396,14 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"site_name\"  WHERE source =~ /^$Controller$/ ",
+        "definition": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"site_name\"  WHERE source =~ /^${Controller:regex}$/ ",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Site",
         "options": [],
-        "query": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"site_name\"  WHERE source =~ /^$Controller$/ ",
+        "query": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"site_name\"  WHERE source =~ /^${Controller:regex}$/ ",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -4418,14 +4418,14 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"ap_name\" WHERE site_name =~ /^$Site$/ ",
+        "definition": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"ap_name\" WHERE site_name =~ /^${Site:regex}$/ ",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "AP",
         "options": [],
-        "query": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"ap_name\" WHERE site_name =~ /^$Site$/ ",
+        "query": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"ap_name\" WHERE site_name =~ /^${Site:regex}$/ ",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -4440,14 +4440,14 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"sw_name\" WHERE site_name =~ /^$Site$/ ",
+        "definition": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"sw_name\" WHERE site_name =~ /^${Site:regex}$/ ",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Switch",
         "options": [],
-        "query": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"sw_name\" WHERE site_name =~ /^$Site$/ ",
+        "query": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"sw_name\" WHERE site_name =~ /^${Site:regex}$/ ",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -4462,14 +4462,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"name\" WHERE site_name =~ /^$Site$/ AND ap_name =~ /^$AP$/ AND is_wired=false",
+        "definition": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"name\" WHERE site_name =~ /^${Site:regex}$/ AND ap_name =~ /^${AP:regex}$/ AND is_wired=false",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Wireless",
         "options": [],
-        "query": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"name\" WHERE site_name =~ /^$Site$/ AND ap_name =~ /^$AP$/ AND is_wired=false",
+        "query": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"name\" WHERE site_name =~ /^${Site:regex}$/ AND ap_name =~ /^${AP:regex}$/ AND is_wired=false",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -4484,14 +4484,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"name\" WHERE site_name =~ /^$Site$/ AND sw_name =~ /^$Switch$/ AND is_wired=true",
+        "definition": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"name\" WHERE site_name =~ /^${Site:regex}$/ AND sw_name =~ /^${Switch:regex}$/ AND is_wired=true",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Wired",
         "options": [],
-        "query": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"name\" WHERE site_name =~ /^$Site$/ AND sw_name =~ /^$Switch$/ AND is_wired=true",
+        "query": "SHOW TAG VALUES FROM \"clients\" WITH KEY = \"name\" WHERE site_name =~ /^${Site:regex}$/ AND sw_name =~ /^${Switch:regex}$/ AND is_wired=true",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/v2.0.0/UniFi-Poller_ Network Sites - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ Network Sites - InfluxDB.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_UNIFI_POLLER",
-      "label": "UniFi Poller",
+      "label": "Unpoller",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -60,7 +60,7 @@
       }
     ]
   },
-  "description": "UniFi Poller v2.0 Displays detailed information for network Sites in a UniFi controller.",
+  "description": "Unpoller v2.9  Displays detailed information for network Sites in a UniFi controller.",
   "editable": true,
   "gnetId": 10414,
   "graphTooltip": 1,
@@ -75,7 +75,7 @@
       "tags": [
         "unifi-poller"
       ],
-      "title": "UniFi Poller",
+      "title": "Unpoller",
       "type": "dashboards"
     },
     {
@@ -219,7 +219,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -334,7 +334,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -449,7 +449,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -564,7 +564,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -751,7 +751,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -857,7 +857,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -972,7 +972,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -1087,7 +1087,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -1202,7 +1202,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -1317,7 +1317,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -1432,7 +1432,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -1547,7 +1547,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -1702,7 +1702,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -1887,7 +1887,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -1993,7 +1993,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -2109,7 +2109,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -2218,7 +2218,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -2327,7 +2327,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -2436,7 +2436,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -2545,7 +2545,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -2660,7 +2660,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -2860,7 +2860,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -2963,7 +2963,7 @@
               "measurement": "subsystems",
               "orderByTime": "ASC",
               "policy": "default",
-              "query": "SELECT max(\"rx_bytes-r\") AS \"Bytes RX\", max(\"tx_bytes-r\") AS \"Bytes TX\" FROM \"subsystems\" WHERE (\"site_name\" =~ /^$site$/) AND $timeFilter GROUP BY time($__interval), \"subsystem\" fill(null)",
+              "query": "SELECT max(\"rx_bytes-r\") AS \"Bytes RX\", max(\"tx_bytes-r\") AS \"Bytes TX\" FROM \"subsystems\" WHERE (\"site_name\" =~ /^${Site:regex}$/) AND $timeFilter GROUP BY time($__interval), \"subsystem\" fill(null)",
               "rawQuery": true,
               "refId": "A",
               "resultFormat": "time_series",
@@ -3009,7 +3009,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -3018,7 +3018,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Site $site Data Transfer",
+          "title": "Site $Site Data Transfer",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -3199,7 +3199,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -3208,7 +3208,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Site $site Client Counts",
+          "title": "Site $Site Client Counts",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -3253,7 +3253,7 @@
           "dashes": false,
           "datasource": "${DS_UNIFI_POLLER}",
           "decimals": 0,
-          "description": "This graph only works if DPI is enabled on the controller and DPI collection is enabled in UniFi Poller. Rx is on the negative axis.",
+          "description": "This graph only works if DPI is enabled on the controller and DPI collection is enabled in Unpoller. Rx is on the negative axis.",
           "fill": 0,
           "fillGradient": 0,
           "gridPos": {
@@ -3383,7 +3383,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -3431,8 +3431,8 @@
           }
         }
       ],
-      "repeat": "site",
-      "title": "Site: $site",
+      "repeat": "Site",
+      "title": "Site: $Site",
       "type": "row"
     }
   ],
@@ -3470,14 +3470,14 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "show tag values from \"subsystems\" with key=\"site_name\" WHERE source =~ /^$Controller$/ ",
+        "definition": "show tag values from \"subsystems\" with key=\"site_name\" WHERE source =~ /^${Controller:regex}$/ ",
         "hide": 2,
         "includeAll": true,
         "label": "",
         "multi": false,
-        "name": "site",
+        "name": "Site",
         "options": [],
-        "query": "show tag values from \"subsystems\" with key=\"site_name\" WHERE source =~ /^$Controller$/ ",
+        "query": "show tag values from \"subsystems\" with key=\"site_name\" WHERE source =~ /^${Controller:regex}$/ ",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/v2.0.0/UniFi-Poller_ UAP Insights - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ UAP Insights - InfluxDB.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_UNIFI_POLLER",
-      "label": "UniFi Poller",
+      "label": "Unpoller",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -72,7 +72,7 @@
       }
     ]
   },
-  "description": "UniFi Poller v2.0 Displays detailed information for wireless access points in a UniFi network.",
+  "description": "Unpoller v2.9  Displays detailed information for wireless access points in a UniFi network.",
   "editable": true,
   "gnetId": 10415,
   "graphTooltip": 1,
@@ -87,7 +87,7 @@
       "tags": [
         "unifi-poller"
       ],
-      "title": "UniFi Poller",
+      "title": "Unpoller",
       "type": "dashboards"
     },
     {
@@ -186,7 +186,7 @@
           "measurement": "uap",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE $timeFilter AND ap_name =~ /$AP$/ AND site_name =~ /$Site$/ GROUP BY \"channel\"",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE $timeFilter AND ap_name =~ /^${AP:regex}$/ AND site_name =~ /^${Site:regex}$/ GROUP BY \"channel\"",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series",
@@ -265,7 +265,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE ($timeFilter  AND  ap_name =~ /$AP$/ AND site_name =~ /$Site$/) GROUP BY \"radio_proto\", \"ap_name\"",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE ($timeFilter  AND  ap_name =~ /^${AP:regex}$/ AND site_name =~ /^${Site:regex}$/) GROUP BY \"radio_proto\", \"ap_name\"",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -348,7 +348,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE $timeFilter AND ap_name =~ /$AP$/ AND site_name =~ /$Site$/ GROUP BY \"oui\"",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE $timeFilter AND ap_name =~ /^${AP:regex}$/ AND site_name =~ /^${Site:regex}$/ GROUP BY \"oui\"",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -460,7 +460,7 @@
           "measurement": "uap_radios",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE ($timeFilter AND ap_name =~ /$AP$/ AND site_name =~ /$Site$/)",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE ($timeFilter AND ap_name =~ /^${AP:regex}$/ AND site_name =~ /^${Site:regex}$/)",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -490,7 +490,7 @@
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -588,7 +588,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE ($timeFilter AND ap_name =~ /$AP$/ AND site_name =~ /$Site$/ AND is_guest = \"true\")",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE ($timeFilter AND ap_name =~ /^${AP:regex}$/ AND site_name =~ /^${Site:regex}$/ AND is_guest = \"true\")",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1150,13 +1150,13 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -1673,13 +1673,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             }
           ]
         }
@@ -1763,13 +1763,13 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -1874,7 +1874,7 @@
           "measurement": "uap",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"mem_used\" FROM \"uap\" WHERE (\"name\" =~ /^$host$/ AND \"site_name\" =~ /^$Site$/) AND $timeFilter GROUP BY \"name\"",
+          "query": "SELECT \"mem_used\" FROM \"uap\" WHERE (\"name\" =~ /^$host$/ AND \"site_name\" =~ /^${Site:regex}$/) AND $timeFilter GROUP BY \"name\"",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1892,13 +1892,13 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -2062,13 +2062,13 @@
             {
               "key": "name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -2208,13 +2208,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             }
           ]
         }
@@ -2384,13 +2384,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             }
           ]
         }
@@ -2550,7 +2550,7 @@
             {
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
@@ -2562,7 +2562,7 @@
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         },
@@ -2630,7 +2630,7 @@
             {
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
@@ -2642,7 +2642,7 @@
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -2778,13 +2778,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             }
           ]
         }
@@ -2918,13 +2918,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "ap_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             }
           ]
         }
@@ -3067,13 +3067,13 @@
             {
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
@@ -3224,13 +3224,13 @@
             {
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
@@ -3420,7 +3420,7 @@
             {
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
@@ -3432,7 +3432,7 @@
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -3615,7 +3615,7 @@
             {
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
@@ -3627,7 +3627,7 @@
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -3811,13 +3811,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
@@ -4001,7 +4001,7 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
@@ -4013,7 +4013,7 @@
               "condition": "AND",
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             }
           ]
         }
@@ -4196,7 +4196,7 @@
             {
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
@@ -4208,7 +4208,7 @@
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -4393,7 +4393,7 @@
             {
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
@@ -4405,7 +4405,7 @@
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -4741,7 +4741,7 @@
             {
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
@@ -4753,7 +4753,7 @@
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -5083,7 +5083,7 @@
             {
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$AP$/"
+              "value": "/^${AP:regex}$/"
             },
             {
               "condition": "AND",
@@ -5095,7 +5095,7 @@
               "condition": "AND",
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             }
           ]
         }
@@ -5181,14 +5181,14 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "show tag values from \"uap\" with key=\"site_name\" where source =~ /$Controller$/",
+        "definition": "show tag values from \"uap\" with key=\"site_name\" where source =~ /^${Controller:regex}$/",
         "hide": 0,
         "includeAll": true,
         "label": "",
         "multi": true,
         "name": "Site",
         "options": [],
-        "query": "show tag values from \"uap\" with key=\"site_name\" where source =~ /$Controller$/",
+        "query": "show tag values from \"uap\" with key=\"site_name\" where source =~ /^${Controller:regex}$/",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -5203,14 +5203,14 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "show tag values from \"uap\" with key=\"name\"  where site_name =~ /$Site$/",
+        "definition": "show tag values from \"uap\" with key=\"name\"  where site_name =~ /^${Site:regex}$/",
         "hide": 0,
         "includeAll": true,
         "label": "UniFi AP:",
         "multi": true,
         "name": "AP",
         "options": [],
-        "query": "show tag values from \"uap\" with key=\"name\"  where site_name =~ /$Site$/",
+        "query": "show tag values from \"uap\" with key=\"name\"  where site_name =~ /^${Site:regex}$/",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/v2.0.0/UniFi-Poller_ USG Insights - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ USG Insights - InfluxDB.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_UNIFI_POLLER",
-      "label": "UniFi Poller",
+      "label": "Unpoller",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -61,7 +61,7 @@
       }
     ]
   },
-  "description": "UniFi Poller v2.0 Displays detailed information for security gateways in a UniFi network.",
+  "description": "Unpoller v2.9  Displays detailed information for security gateways in a UniFi network.",
   "editable": true,
   "gnetId": 10416,
   "graphTooltip": 2,
@@ -76,7 +76,7 @@
       "tags": [
         "unifi-poller"
       ],
-      "title": "UniFi Poller",
+      "title": "Unpoller",
       "type": "dashboards"
     },
     {
@@ -594,7 +594,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -719,7 +719,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -845,7 +845,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -971,7 +971,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -1095,7 +1095,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -1219,7 +1219,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -1343,7 +1343,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -1470,7 +1470,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -1597,7 +1597,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -1723,7 +1723,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -1847,7 +1847,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -1971,7 +1971,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -2315,7 +2315,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             },
@@ -2424,7 +2424,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -2569,7 +2569,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -2761,7 +2761,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             },
@@ -2836,7 +2836,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -3028,7 +3028,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -3223,7 +3223,7 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
@@ -3431,7 +3431,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -3682,7 +3682,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -3933,7 +3933,7 @@
                   "condition": "AND",
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 }
               ]
             }
@@ -4201,14 +4201,14 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "show tag values from \"usg\" with key=\"site_name\" where source =~ /$Controller$/",
+        "definition": "show tag values from \"usg\" with key=\"site_name\" where source =~ /^${Controller:regex}$/",
         "hide": 0,
         "includeAll": true,
         "label": "",
         "multi": true,
         "name": "Site",
         "options": [],
-        "query": "show tag values from \"usg\" with key=\"site_name\" where source =~ /$Controller$/",
+        "query": "show tag values from \"usg\" with key=\"site_name\" where source =~ /^${Controller:regex}$/",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -4223,14 +4223,14 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "show tag values from \"usg\" with key=\"name\" where site_name =~ /$Site$/",
+        "definition": "show tag values from \"usg\" with key=\"name\" where site_name =~ /^${Site:regex}$/",
         "hide": 2,
         "includeAll": true,
         "label": "UniFi USG:",
         "multi": false,
         "name": "host",
         "options": [],
-        "query": "show tag values from \"usg\" with key=\"name\" where site_name =~ /$Site$/",
+        "query": "show tag values from \"usg\" with key=\"name\" where site_name =~ /^${Site:regex}$/",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/v2.0.0/UniFi-Poller_ USW Insights - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ USW Insights - InfluxDB.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_UNIFI_POLLER",
-      "label": "UniFi Poller",
+      "label": "Unpoller",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -48,7 +48,7 @@
       }
     ]
   },
-  "description": "UniFi Poller v2.0.1 Displays detailed information for network switches in a UniFi network.",
+  "description": "Unpoller v2.9  Displays detailed information for network switches in a UniFi network.",
   "editable": true,
   "gnetId": 10417,
   "graphTooltip": 1,
@@ -63,7 +63,7 @@
       "tags": [
         "unifi-poller"
       ],
-      "title": "UniFi Poller",
+      "title": "Unpoller",
       "type": "dashboards"
     },
     {
@@ -567,13 +567,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         },
@@ -635,13 +635,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         },
@@ -750,13 +750,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         },
@@ -848,13 +848,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         }
@@ -1006,13 +1006,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         },
@@ -1067,13 +1067,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         },
@@ -1128,13 +1128,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         }
@@ -1318,13 +1318,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         },
@@ -1379,13 +1379,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         },
@@ -1440,13 +1440,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         }
@@ -1597,13 +1597,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         },
@@ -1658,13 +1658,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         },
@@ -1719,13 +1719,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         }
@@ -1912,19 +1912,19 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             },
             {
               "condition": "AND",
               "key": "port_id",
               "operator": "=~",
-              "value": "/^$Port$/"
+              "value": "/^${Port:regex}$/"
             }
           ]
         }
@@ -2515,13 +2515,13 @@
             {
               "key": "site_name",
               "operator": "=~",
-              "value": "/^$Site$/"
+              "value": "/^${Site:regex}$/"
             },
             {
               "condition": "AND",
               "key": "device_name",
               "operator": "=~",
-              "value": "/^$Switch$/"
+              "value": "/^${Switch:regex}$/"
             }
           ]
         }
@@ -2993,19 +2993,19 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "device_name",
                   "operator": "=~",
-                  "value": "/^$Switch$/"
+                  "value": "/^${Switch:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "port_id",
                   "operator": "=~",
-                  "value": "/^$Port$/"
+                  "value": "/^${Port:regex}$/"
                 }
               ]
             }
@@ -3160,19 +3160,19 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "device_name",
                   "operator": "=~",
-                  "value": "/^$Switch$/"
+                  "value": "/^${Switch:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "port_id",
                   "operator": "=~",
-                  "value": "/^$Port$/"
+                  "value": "/^${Port:regex}$/"
                 }
               ]
             }
@@ -3385,19 +3385,19 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "device_name",
                   "operator": "=~",
-                  "value": "/^$Switch$/"
+                  "value": "/^${Switch:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "port_id",
                   "operator": "=~",
-                  "value": "/^$Port$/"
+                  "value": "/^${Port:regex}$/"
                 }
               ]
             }
@@ -3635,19 +3635,19 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "device_name",
                   "operator": "=~",
-                  "value": "/^$Switch$/"
+                  "value": "/^${Switch:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "port_id",
                   "operator": "=~",
-                  "value": "/^$Port$/"
+                  "value": "/^${Port:regex}$/"
                 }
               ]
             }
@@ -3837,19 +3837,19 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "device_name",
                   "operator": "=~",
-                  "value": "/^$Switch$/"
+                  "value": "/^${Switch:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "port_id",
                   "operator": "=~",
-                  "value": "/^$Port$/"
+                  "value": "/^${Port:regex}$/"
                 }
               ]
             }
@@ -3997,19 +3997,19 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "device_name",
                   "operator": "=~",
-                  "value": "/^$Switch$/"
+                  "value": "/^${Switch:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "port_id",
                   "operator": "=~",
-                  "value": "/^$Port$/"
+                  "value": "/^${Port:regex}$/"
                 }
               ]
             }
@@ -4157,19 +4157,19 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "device_name",
                   "operator": "=~",
-                  "value": "/^$Switch$/"
+                  "value": "/^${Switch:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "port_id",
                   "operator": "=~",
-                  "value": "/^$Port$/"
+                  "value": "/^${Port:regex}$/"
                 }
               ]
             }
@@ -4317,19 +4317,19 @@
                 {
                   "key": "site_name",
                   "operator": "=~",
-                  "value": "/^$Site$/"
+                  "value": "/^${Site:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "device_name",
                   "operator": "=~",
-                  "value": "/^$Switch$/"
+                  "value": "/^${Switch:regex}$/"
                 },
                 {
                   "condition": "AND",
                   "key": "port_id",
                   "operator": "=~",
-                  "value": "/^$Port$/"
+                  "value": "/^${Port:regex}$/"
                 }
               ]
             }
@@ -4417,14 +4417,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "show tag values from \"usw_ports\" with key=\"site_name\" WHERE source =~ /^$Controller$/ ",
+        "definition": "show tag values from \"usw_ports\" with key=\"site_name\" WHERE source =~ /^${Controller:regex}$/ ",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Site",
         "options": [],
-        "query": "show tag values from \"usw_ports\" with key=\"site_name\" WHERE source =~ /^$Controller$/ ",
+        "query": "show tag values from \"usw_ports\" with key=\"site_name\" WHERE source =~ /^${Controller:regex}$/ ",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -4481,14 +4481,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "show tag values from \"usw_ports\" with key=\"device_name\" where site_name =~ /^$Site$/ AND type=~/^$Devices$/",
+        "definition": "show tag values from \"usw_ports\" with key=\"device_name\" where site_name =~ /^${Site:regex}$/ AND type =~ /^${Devices:regex}$/",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Switch",
         "options": [],
-        "query": "show tag values from \"usw_ports\" with key=\"device_name\" where site_name =~ /^$Site$/ AND type=~/^$Devices$/",
+        "query": "show tag values from \"usw_ports\" with key=\"device_name\" where site_name =~ /^${Site:regex}$/ AND type =~ /^${Devices:regex}$/",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -4503,14 +4503,14 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_UNIFI_POLLER}",
-        "definition": "show tag values from \"usw_ports\" with key=\"port_id\" where device_name =~ /^$Switch$/ AND site_name =~ /^$Site$/",
+        "definition": "show tag values from \"usw_ports\" with key=\"port_id\" where device_name =~ /^${Switch:regex}$/ AND site_name =~ /^${Site:regex}$/",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Port",
         "options": [],
-        "query": "show tag values from \"usw_ports\" with key=\"port_id\" where device_name =~ /^$Switch$/ AND site_name =~ /^$Site$/",
+        "query": "show tag values from \"usw_ports\" with key=\"port_id\" where device_name =~ /^${Switch:regex}$/ AND site_name =~ /^${Site:regex}$/",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
replace all $Site with ${Site:regex} from https://github.com/unpoller/dashboards/issues/25\#issuecomment-1920382559

NOTE: this is untested against older versions of grafana, but it seems many users are now working around this. Thanks to @vidia for the find 