### PR TITLE
Fix use of interval variable in rate functions

### DIFF
--- a/v2.0.0/UniFi-Poller_ Client DPI - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ Client DPI - Prometheus.json
@@ -526,13 +526,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (category)(rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__interval]))",
+          "expr": "sum by (category)(rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__rate_interval]))",
           "interval": "$Smooth",
           "legendFormat": " {{category}} Rx",
           "refId": "A"
         },
         {
-          "expr": "sum by (category)(rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\",  category=~\"$Category\"}[$__interval]))",
+          "expr": "sum by (category)(rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\",  category=~\"$Category\"}[$__rate_interval]))",
           "interval": "$Smooth",
           "legendFormat": "{{category}} Tx",
           "refId": "B"
@@ -641,13 +641,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (category)(rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__interval]))",
+          "expr": "sum by (category)(rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__rate_interval]))",
           "interval": "$Smooth",
           "legendFormat": " {{category}} Rx",
           "refId": "A"
         },
         {
-          "expr": "sum by (category)(rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__interval]))",
+          "expr": "sum by (category)(rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=~\"$Category\"}[$__rate_interval]))",
           "interval": "$Smooth",
           "legendFormat": "{{category}} Tx",
           "refId": "B"
@@ -768,7 +768,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -880,7 +880,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -992,7 +992,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1104,7 +1104,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1216,7 +1216,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1328,7 +1328,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1440,7 +1440,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1552,7 +1552,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1664,7 +1664,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1776,7 +1776,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -1888,7 +1888,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2000,7 +2000,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2112,7 +2112,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2224,7 +2224,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2336,7 +2336,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2448,7 +2448,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2560,7 +2560,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2672,7 +2672,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2784,7 +2784,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -2896,7 +2896,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3008,7 +3008,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3120,7 +3120,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3232,7 +3232,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3344,7 +3344,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3456,7 +3456,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3568,7 +3568,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3680,7 +3680,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3792,7 +3792,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -3904,7 +3904,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4016,7 +4016,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4128,7 +4128,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4240,7 +4240,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4352,7 +4352,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4464,7 +4464,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4576,7 +4576,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4688,7 +4688,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4800,7 +4800,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -4912,7 +4912,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5024,7 +5024,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5136,7 +5136,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5248,7 +5248,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5360,7 +5360,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5472,7 +5472,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5584,7 +5584,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5696,7 +5696,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5808,7 +5808,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -5920,7 +5920,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6032,7 +6032,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6144,7 +6144,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6256,7 +6256,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6368,7 +6368,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6480,7 +6480,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6592,7 +6592,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6704,7 +6704,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6816,7 +6816,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -6928,7 +6928,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7040,7 +7040,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7152,7 +7152,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7264,7 +7264,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7376,7 +7376,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7488,7 +7488,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7600,7 +7600,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7712,7 +7712,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7824,7 +7824,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -7936,7 +7936,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8048,7 +8048,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8160,7 +8160,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8272,7 +8272,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8384,7 +8384,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8496,7 +8496,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8608,7 +8608,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8733,7 +8733,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8845,7 +8845,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -8957,7 +8957,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9069,7 +9069,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9181,7 +9181,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9293,7 +9293,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9405,7 +9405,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9517,7 +9517,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9629,7 +9629,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9741,7 +9741,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9853,7 +9853,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -9965,7 +9965,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10077,7 +10077,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10189,7 +10189,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10301,7 +10301,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10413,7 +10413,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10525,7 +10525,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10637,7 +10637,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10749,7 +10749,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10861,7 +10861,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -10973,7 +10973,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11085,7 +11085,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11197,7 +11197,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11309,7 +11309,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11421,7 +11421,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11533,7 +11533,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11645,7 +11645,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11757,7 +11757,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11869,7 +11869,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -11981,7 +11981,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12093,7 +12093,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12205,7 +12205,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12317,7 +12317,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12429,7 +12429,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12541,7 +12541,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12653,7 +12653,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12765,7 +12765,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12877,7 +12877,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -12989,7 +12989,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13101,7 +13101,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13213,7 +13213,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13325,7 +13325,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13437,7 +13437,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13549,7 +13549,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13661,7 +13661,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13773,7 +13773,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13885,7 +13885,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -13997,7 +13997,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14109,7 +14109,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14221,7 +14221,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14333,7 +14333,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14445,7 +14445,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14557,7 +14557,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14669,7 +14669,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14781,7 +14781,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -14893,7 +14893,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15005,7 +15005,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15117,7 +15117,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15229,7 +15229,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15341,7 +15341,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15453,7 +15453,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15565,7 +15565,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15677,7 +15677,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15802,7 +15802,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -15914,7 +15914,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16026,7 +16026,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16138,7 +16138,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16250,7 +16250,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16362,7 +16362,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16474,7 +16474,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16586,7 +16586,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16698,7 +16698,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16810,7 +16810,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -16922,7 +16922,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17034,7 +17034,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17146,7 +17146,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17258,7 +17258,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17370,7 +17370,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17482,7 +17482,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17594,7 +17594,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17706,7 +17706,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17818,7 +17818,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -17930,7 +17930,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18042,7 +18042,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18154,7 +18154,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18266,7 +18266,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18378,7 +18378,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18490,7 +18490,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18602,7 +18602,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18714,7 +18714,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18826,7 +18826,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -18938,7 +18938,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19050,7 +19050,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19162,7 +19162,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19274,7 +19274,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19386,7 +19386,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19498,7 +19498,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19610,7 +19610,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19722,7 +19722,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19834,7 +19834,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -19946,7 +19946,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20058,7 +20058,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20170,7 +20170,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20282,7 +20282,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20394,7 +20394,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20506,7 +20506,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20618,7 +20618,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20730,7 +20730,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20842,7 +20842,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -20954,7 +20954,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21066,7 +21066,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21178,7 +21178,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21290,7 +21290,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21402,7 +21402,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21514,7 +21514,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21626,7 +21626,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21738,7 +21738,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21850,7 +21850,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -21962,7 +21962,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22074,7 +22074,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22186,7 +22186,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22298,7 +22298,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22410,7 +22410,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22522,7 +22522,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22634,7 +22634,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22746,7 +22746,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
               "refId": "A"
@@ -22871,7 +22871,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]!~\"TOTAL\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -22984,7 +22984,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23097,7 +23097,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23210,7 +23210,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23323,7 +23323,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23436,7 +23436,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23549,7 +23549,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23662,7 +23662,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23775,7 +23775,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -23888,7 +23888,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24001,7 +24001,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24114,7 +24114,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24227,7 +24227,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24340,7 +24340,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24453,7 +24453,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24566,7 +24566,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24679,7 +24679,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24792,7 +24792,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -24905,7 +24905,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25018,7 +25018,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25131,7 +25131,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25244,7 +25244,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25357,7 +25357,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25470,7 +25470,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25583,7 +25583,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25696,7 +25696,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25809,7 +25809,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -25922,7 +25922,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26035,7 +26035,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26148,7 +26148,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26261,7 +26261,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26374,7 +26374,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26487,7 +26487,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26600,7 +26600,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26713,7 +26713,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26826,7 +26826,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -26939,7 +26939,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27052,7 +27052,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27165,7 +27165,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27278,7 +27278,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27391,7 +27391,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27504,7 +27504,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27617,7 +27617,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27730,7 +27730,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27843,7 +27843,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -27956,7 +27956,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28069,7 +28069,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28182,7 +28182,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28295,7 +28295,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28408,7 +28408,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28521,7 +28521,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28634,7 +28634,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28747,7 +28747,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28860,7 +28860,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -28973,7 +28973,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29086,7 +29086,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29199,7 +29199,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29312,7 +29312,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29425,7 +29425,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29538,7 +29538,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29651,7 +29651,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29764,7 +29764,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -29877,7 +29877,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__interval])",
+              "expr": "rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\"}[$__rate_interval])",
               "instant": false,
               "interval": "$Smooth",
               "legendFormat": "{{application}} ({{category}})",
@@ -30002,7 +30002,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
+              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_receive_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__rate_interval]))",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{mac}} ({{application}})",
               "refId": "A"
@@ -30109,7 +30109,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
+              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_transmit_bytes{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__rate_interval]))",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{mac}} ({{application}})",
               "refId": "A"
@@ -30217,7 +30217,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
+              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_receive_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__rate_interval]))",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{mac}} ({{application}})",
               "refId": "A"
@@ -30324,7 +30324,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__interval]))",
+              "expr": "sum by ($Identifier,application) (rate(unpoller_client_dpi_transmit_packets{site_name=~\"$Site\", [[Identifier]]=~\"$Client\", [[Identifier]]!~\"TOTAL\", category=\"$Category\"}[$__rate_interval]))",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{mac}} ({{application}})",
               "refId": "A"
@@ -30593,5 +30593,5 @@
   "timezone": "browser",
   "title": "UniFi-Poller: Client DPI - Prometheus",
   "uid": "w3usaHLZk",
-  "version": 50
+  "version": 51
 }

--- a/v2.0.0/UniFi-Poller_ Client Insights - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ Client Insights - Prometheus.json
@@ -1281,14 +1281,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__rate_interval]))",
           "instant": false,
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}} Tx",
           "refId": "B"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__rate_interval]))",
           "instant": false,
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}} Rx",
@@ -1396,13 +1396,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__rate_interval]))",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}} Tx",
           "refId": "A"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name!~\".*camera.*|.*cam(era)?$\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__rate_interval]))",
           "hide": false,
           "interval": "$Smooth",
           "intervalFactor": 1,
@@ -1511,28 +1511,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name=~\"^amazon.*\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name=~\"^amazon.*\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__rate_interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "w {{name}} {{mac}} Tx",
           "refId": "A"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name=~\"^amazon.*\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name=~\"^amazon.*\", name=~\"$Wireless\", site_name=~\"$Site\", ap_name=~\"$AP\"}[$__rate_interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "w {{name}} {{mac}} Rx",
           "refId": "B"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name=~\"^amazon.*\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{name=~\"^amazon.*\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__rate_interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "e {{name}} {{mac}} Tx",
           "refId": "C"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name=~\"^amazon.*\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{name=~\"^amazon.*\", name=~\"$Wired\", site_name=~\"$Site\", sw_name=~\"$Switch\"}[$__rate_interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "e {{name}} {{mac}} Rx",
@@ -1640,7 +1640,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{ap_name=~\"$AP\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{ap_name=~\"$AP\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "interval": "$Smooth",
@@ -1648,21 +1648,21 @@
           "refId": "A"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{ap_name=~\"$AP\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{ap_name=~\"$AP\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__rate_interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "w {{name}} {{mac}} Rx",
           "refId": "B"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{sw_name=~\"$Switch\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_bytes_total{sw_name=~\"$Switch\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__rate_interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "e {{name}} {{mac}} Tx",
           "refId": "C"
         },
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{sw_name=~\"$Switch\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_receive_bytes_total{sw_name=~\"$Switch\", name=~\".*camera.*|.*cam$\", site_name=~\"$Site\"}[$__rate_interval]))",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "e {{name}} {{mac}} Rx",
@@ -2180,7 +2180,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by ($Identifier) (rate(unpoller_client_wifi_attempts_transmit_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"}[$__interval]))",
+          "expr": "avg by ($Identifier) (rate(unpoller_client_wifi_attempts_transmit_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"}[$__rate_interval]))",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -2388,7 +2388,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_retries_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"}[$__interval]))",
+          "expr": "sum by ($Identifier) (rate(unpoller_client_transmit_retries_total{ap_name=~\"$AP\", site_name=~\"$Site\", name=~\"$Wireless\"}[$__rate_interval]))",
           "interval": "$Smooth",
           "legendFormat": "{{name}} {{mac}}",
           "refId": "A"
@@ -3214,5 +3214,5 @@
   "timezone": "browser",
   "title": "UniFi-Poller: Client Insights - Prometheus",
   "uid": "jMfvAjxWz",
-  "version": 30
+  "version": 31
 }

--- a/v2.0.0/UniFi-Poller_ Network Sites - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ Network Sites - Prometheus.json
@@ -1189,13 +1189,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_site_remote_user_transmit_bytes_total{site_name=~\"$Site\"}[$__interval])",
+              "expr": "rate(unpoller_site_remote_user_transmit_bytes_total{site_name=~\"$Site\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "VPN Users Tx",
               "refId": "A"
             },
             {
-              "expr": "rate(unpoller_site_remote_user_receive_bytes_total{site_name=~\"$Site\"}[$__interval])",
+              "expr": "rate(unpoller_site_remote_user_receive_bytes_total{site_name=~\"$Site\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "VPN Users Rx",
               "refId": "B"
@@ -1306,14 +1306,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (category) (rate(unpoller_site_dpi_receive_bytes{site_name=~\"$Site\"}[$__interval]))",
+              "expr": "sum by (category) (rate(unpoller_site_dpi_receive_bytes{site_name=~\"$Site\"}[$__rate_interval]))",
               "hide": false,
               "interval": "$Smooth",
               "legendFormat": "{{category}} Rx",
               "refId": "A"
             },
             {
-              "expr": "sum by (category) (rate(unpoller_site_dpi_transmit_bytes{site_name=~\"$Site\"}[$__interval]))",
+              "expr": "sum by (category) (rate(unpoller_site_dpi_transmit_bytes{site_name=~\"$Site\"}[$__rate_interval]))",
               "hide": false,
               "interval": "$Smooth",
               "legendFormat": "{{category}} Tx",
@@ -1518,5 +1518,5 @@
   "timezone": "browser",
   "title": "UniFi-Poller: Network Sites - Prometheus",
   "uid": "9WaGWZaZk",
-  "version": 9
+  "version": 10
 }

--- a/v2.0.0/UniFi-Poller_ UAP Insights - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ UAP Insights - Prometheus.json
@@ -3024,14 +3024,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(unpoller_device_vap_transmit_packets_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_packets_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "hide": false,
           "interval": "$Smooth",
           "legendFormat": "{{name}} Out",
           "refId": "A"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_packets_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_packets_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} In",
           "refId": "B"
@@ -3143,13 +3143,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(unpoller_device_vap_transmit_packets_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_packets_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Out",
           "refId": "A"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_packets_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_packets_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} In",
           "refId": "B"
@@ -3261,49 +3261,49 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_dropped_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_dropped_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Drops Rx",
           "refId": "A"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_transmit_dropped_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_dropped_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Drops Tx",
           "refId": "B"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_errors_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_errors_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Errors Rx",
           "refId": "C"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_transmit_errors_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_errors_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Errors Tx",
           "refId": "D"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_crypts_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_crypts_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Crypts Rx",
           "refId": "E"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_frags_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_frags_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Frags Rx",
           "refId": "F"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_nwids_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_nwids_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Nwids Rx",
           "refId": "G"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_transmit_retries_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_retries_total{radio=\"na\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Retries Tx",
           "refId": "H"
@@ -3416,49 +3416,49 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_dropped_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_dropped_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Drops Rx",
           "refId": "A"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_transmit_dropped_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_dropped_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Drops Tx",
           "refId": "B"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_errors_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_errors_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Errors Rx",
           "refId": "C"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_transmit_errors_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_errors_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Errors Tx",
           "refId": "D"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_crypts_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_crypts_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Crypts Rx",
           "refId": "E"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_frags_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_frags_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Frags Rx",
           "refId": "F"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_receive_nwids_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_receive_nwids_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Nwids Rx",
           "refId": "G"
         },
         {
-          "expr": "sum (rate(unpoller_device_vap_transmit_retries_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__interval])) by (name)",
+          "expr": "sum (rate(unpoller_device_vap_transmit_retries_total{radio=\"ng\",site_name=~\"$Site\",name=~\"$AP\"}[$__rate_interval])) by (name)",
           "interval": "$Smooth",
           "legendFormat": "{{name}} Retries Tx",
           "refId": "H"
@@ -3676,5 +3676,5 @@
   "timezone": "browser",
   "title": "UniFi-Poller: UAP Insights - Prometheus",
   "uid": "g5wFWqxZk",
-  "version": 24
+  "version": 25
 }

--- a/v2.0.0/UniFi-Poller_ USG Insights - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ USG Insights - Prometheus.json
@@ -1500,13 +1500,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_device_wan_receive_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Bytes Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unpoller_device_wan_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Bytes Tx",
               "refId": "B"
@@ -1637,13 +1637,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_device_lan_receive_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_lan_receive_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Bytes Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unpoller_device_lan_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_lan_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Bytes Tx",
               "refId": "B"
@@ -1763,13 +1763,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_device_wan_receive_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Packets Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unpoller_device_wan_transmit_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Packets Tx",
               "refId": "B"
@@ -1890,13 +1890,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_device_lan_receive_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_lan_receive_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Packets Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unpoller_device_lan_transmit_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_lan_transmit_packets_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Packets Tx",
               "refId": "B"
@@ -2018,25 +2018,25 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_device_wan_transmit_broadcast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_broadcast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Broadcast Tx",
               "refId": "D"
             },
             {
-              "expr": "rate(unpoller_device_wan_receive_broadcast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_broadcast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Broadcast Rx",
               "refId": "C"
             },
             {
-              "expr": "rate(unpoller_device_wan_receive_multicast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_multicast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}}  Multicast Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unpoller_device_wan_transmit_multicast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_multicast_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Multicast Tx",
               "refId": "B"
@@ -2158,25 +2158,25 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_device_wan_transmit_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Drops Tx",
               "refId": "A"
             },
             {
-              "expr": "rate(unpoller_device_wan_receive_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Drops Rx",
               "refId": "B"
             },
             {
-              "expr": "rate(unpoller_device_wan_transmit_errors_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_transmit_errors_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Errors Tx",
               "refId": "C"
             },
             {
-              "expr": "rate(unpoller_device_wan_receive_errors_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_wan_receive_errors_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Errors Rx",
               "refId": "D"
@@ -2295,7 +2295,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_device_lan_receive_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__interval])",
+              "expr": "rate(unpoller_device_lan_receive_dropped_total{site_name=~\"$Site\", name=~\"$Gateway\"}[$__rate_interval])",
               "hide": false,
               "interval": "$Smooth",
               "legendFormat": "{{name}} {{port}} Dropped Rx",
@@ -2522,5 +2522,5 @@
   "timezone": "browser",
   "title": "UniFi-Poller: USG Insights - Prometheus",
   "uid": "4Yo8IZ-Wk",
-  "version": 36
+  "version": 37
 }

--- a/v2.0.0/UniFi-Poller_ USW Insights - Prometheus.json
+++ b/v2.0.0/UniFi-Poller_ USW Insights - Prometheus.json
@@ -921,13 +921,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(unpoller_device_port_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Switch\", port_id=~\"$Port\"}[$__interval])",
+          "expr": "rate(unpoller_device_port_transmit_bytes_total{site_name=~\"$Site\", name=~\"$Switch\", port_id=~\"$Port\"}[$__rate_interval])",
           "interval": "$Smooth",
           "legendFormat": "{{port_id}} {{port_name}} Tx",
           "refId": "A"
         },
         {
-          "expr": "rate(unpoller_device_port_receive_bytes_total{site_name=~\"$Site\", name=~\"$Switch\", port_id=~\"$Port\"}[$__interval])",
+          "expr": "rate(unpoller_device_port_receive_bytes_total{site_name=~\"$Site\", name=~\"$Switch\", port_id=~\"$Port\"}[$__rate_interval])",
           "interval": "$Smooth",
           "legendFormat": "{{port_id}} {{port_name}} Rx",
           "refId": "B"
@@ -1894,13 +1894,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_device_port_receive_bytes_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_bytes_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": " {{port_id}} ({{port_name}}) Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unpoller_device_port_transmit_bytes_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_bytes_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": " {{port_id}} ({{port_name}}) Tx",
               "refId": "B"
@@ -2008,25 +2008,25 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_device_port_receive_broadcast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_broadcast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Broadcast Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unpoller_device_port_transmit_broadcast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_broadcast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Broadcast Tx",
               "refId": "B"
             },
             {
-              "expr": "rate(unpoller_device_port_receive_multicast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_multicast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Multicast Rx",
               "refId": "C"
             },
             {
-              "expr": "rate(unpoller_device_port_transmit_multicast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_multicast_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Multicast Tx",
               "refId": "D"
@@ -2136,25 +2136,25 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_device_port_receive_dropped_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_dropped_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Drops Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unpoller_device_port_transmit_dropped_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_dropped_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Drops Tx",
               "refId": "B"
             },
             {
-              "expr": "rate(unpoller_device_port_transmit_errors_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_errors_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Errors Tx",
               "refId": "C"
             },
             {
-              "expr": "rate(unpoller_device_port_receive_errors_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_errors_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Errors Rx",
               "refId": "D"
@@ -2265,13 +2265,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(unpoller_device_port_receive_packets_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_receive_packets_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Rx",
               "refId": "A"
             },
             {
-              "expr": "rate(unpoller_device_port_transmit_packets_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__interval])",
+              "expr": "rate(unpoller_device_port_transmit_packets_total{site_name=~\"$Site\", port_id=~\"$Port\"}[$__rate_interval])",
               "interval": "$Smooth",
               "legendFormat": "{{port_id}} ({{port_name}}) Tx",
               "refId": "B"
@@ -2873,5 +2873,5 @@
   "timezone": "browser",
   "title": "UniFi-Poller: USW Insights - Prometheus",
   "uid": "FsfxpWaZz",
-  "version": 35
+  "version": 36
 }


### PR DESCRIPTION
Use the `$__rate_interval` variable in rate calculations. This correctly handles the datasource minimum scrape interval.

Fixes: https://github.com/unpoller/dashboards/issues/30