### PR TITLE
Fix Client MAC OUI Breakdown rendering issue

### DIFF
--- a/v2.0.0/UniFi-Poller_ Client Insights - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ Client Insights - InfluxDB.json
@@ -1068,7 +1068,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND site_name =~ /^${Site:regex}$/ AND ((\"name\" =~ /^${Wireless:regex}$/ AND \"ap_name\" =~ /^${AP:regex}$/) OR (\"name\" =~ /^${Wired:regex}$/ AND \"sw_name\" =~ /^${Switch:regex}$/ )) GROUP BY \"oui\"",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND site_name =~ /^${Site:regex}$/ AND ((\"name\" =~ /^${Wireless:regex}$/ AND \"ap_name\" =~ /^${AP:regex}$/) OR (\"name\" =~ /^${Wired:regex}$/ AND \"sw_name\" =~ /^${Switch:regex}$/ )) AND \"oui\" != '' GROUP BY \"oui\"",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",


### PR DESCRIPTION
Fixes issue where the "Client MAC OUI Breakdown" panel shows approximately one third of the chart labeled as "Value" instead of the manufacturer name.

## Changes
- Added `AND "oui" != ''` filter to the InfluxDB query to exclude clients with empty OUI fields

## Impact
This prevents empty OUI values from appearing as "Value" in the pie chart, providing cleaner visualization of client manufacturers.

## Testing
Tested on Grafana server with InfluxDB backend (unpoller database) and confirmed that entries with empty OUI fields are now filtered out.