### PR TITLE
Fix Client MAC OUI Breakdown in UAP Insights InfluxDB dashboard

### DIFF
--- a/v2.0.0/UniFi-Poller_ Client Insights - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ Client Insights - InfluxDB.json
@@ -1068,7 +1068,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND site_name =~ /^${Site:regex}$/ AND ((\"name\" =~ /^${Wireless:regex}$/ AND \"ap_name\" =~ /^${AP:regex}$/) OR (\"name\" =~ /^${Wired:regex}$/ AND \"sw_name\" =~ /^${Switch:regex}$/ )) GROUP BY \"oui\"",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE time > now() - 5m AND site_name =~ /^${Site:regex}$/ AND ((\"name\" =~ /^${Wireless:regex}$/ AND \"ap_name\" =~ /^${AP:regex}$/) OR (\"name\" =~ /^${Wired:regex}$/ AND \"sw_name\" =~ /^${Switch:regex}$/ )) AND \"oui\" != '' GROUP BY \"oui\"",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",

--- a/v2.0.0/UniFi-Poller_ UAP Insights - InfluxDB.json
+++ b/v2.0.0/UniFi-Poller_ UAP Insights - InfluxDB.json
@@ -348,7 +348,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE $timeFilter AND ap_name =~ /^${AP:regex}$/ AND site_name =~ /^${Site:regex}$/ GROUP BY \"oui\"",
+          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE $timeFilter AND ap_name =~ /^${AP:regex}$/ AND site_name =~ /^${Site:regex}$/ AND \"oui\" != '' GROUP BY \"oui\"",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",


### PR DESCRIPTION
Fixes the same OUI rendering issue in the UAP Insights InfluxDB dashboard as addressed in PR #50.

## Changes
- Added `AND "oui" != ''` filter to the Client / MAC OUI panel query to exclude clients with empty OUI fields

## Impact
This prevents empty OUI values from appearing as "Value" in the pie chart, providing cleaner visualization of client manufacturers.